### PR TITLE
Moved Cesium CSS reference to index.html.

### DIFF
--- a/examples/cesium/index.html
+++ b/examples/cesium/index.html
@@ -4,12 +4,13 @@
 <meta charset="UTF-8" />
 <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no"/>
-<link rel="stylesheet" type="text/css" media="screen,print" href="style.css" />
 <title>Cesium.js + glTF Loader</title>
 <script src="../../sampleModels/model-index.js"></script>
 <script src="../../tutorialModels/model-index.js"></script>
 <!-- Cesium.js -->
 <script src="../../libs/cesium/1.30/Cesium.js"></script>
+<link rel="stylesheet" href="../../libs/cesium/1.30/Widgets/widgets.css" />
+<link rel="stylesheet" type="text/css" media="screen,print" href="style.css" />
 </head>
 <body>
 <div id="cesiumContainer"></div>

--- a/examples/cesium/style.css
+++ b/examples/cesium/style.css
@@ -1,5 +1,3 @@
-@import url("../../libs/cesium/1.26/Widgets/widgets.css");
-
 html, body, #cesiumContainer {
     position: absolute;
     top: 0;


### PR DESCRIPTION
The `index.html` file had the JavaScript reference updated from Cesium 1.26 to 1.30, but the stylesheet was still importing CSS from 1.26.  This updates and moves the stylesheet reference into `index.html` alongside the JavaScript reference, so that future updates should get both at the same time.

I don't think the old CSS was causing any problems with the glTF tests, but it would become noticeable once Cesium adds the perspective/orthographic selection widget.