### PR TITLE
improve x3dom gltf-binary loader

### DIFF
--- a/examples/x3dom/index.html
+++ b/examples/x3dom/index.html
@@ -14,6 +14,7 @@
 
 <!-- x3dom.debug.js 1.7.3-dev -->
 <script src="../../libs/x3dom/1.7.3dev/x3dom.debug.js"></script>
+<script src="https://rawgit.com/andreasplesch/41f29833c4bbe2e638b3acae0d49f160/raw/09d2d97243c89515ff2fcc7aeebce8f763cbc34c/x3dom_glTFfixer.user.js"></script>
 
 <x3d id="x3d" width="100%" height="100%"> 
     <scene>

--- a/examples/x3dom/index.html
+++ b/examples/x3dom/index.html
@@ -14,7 +14,7 @@
 
 <!-- x3dom.debug.js 1.7.3-dev -->
 <script src="../../libs/x3dom/1.7.3dev/x3dom.debug.js"></script>
-<script src="https://rawgit.com/andreasplesch/41f29833c4bbe2e638b3acae0d49f160/raw/526d0bb4fd8b5640d1082b4b8b7c44fa5a917cea/x3dom_glTFfixer.user.js"></script>
+<script src="../../libs/x3dom/1.7.3dev/x3dom_glTFfixer.user.js"></script>
 <x3d id="x3d" width="100%" height="100%"> 
     <scene>
         <Environment frustumCulling='false'></Environment>

--- a/examples/x3dom/index.html
+++ b/examples/x3dom/index.html
@@ -23,7 +23,7 @@
         <Transform DEF="model" rotation="0 1 0 0" id="gltf">
             <!-- <ExternalShape id="exshape" url="https://cdn.rawgit.com/cx20/gltf-test/master/sampleModels/Duck/glTF-Binary/Duck.glb"></ExternalShape> -->
         </Transform>                
-        <timeSensor DEF="time" cycleInterval="2" loop="true"></timeSensor>
+        <timeSensor DEF="time" cycleInterval="20" loop="true"></timeSensor>
         <OrientationInterpolator DEF="move" key="0 0.5 1" keyValue="0 1 0 0, 0 1 0 3.14, 0 1 0 6.28"/>
         <Route fromNode="time" fromField ="fraction_changed" toNode="move" toField="set_fraction"></Route>
         <Route fromNode="move" fromField ="value_changed" toNode="model" toField="rotation"></Route>

--- a/examples/x3dom/index.html
+++ b/examples/x3dom/index.html
@@ -18,7 +18,7 @@
 <x3d id="x3d" width="100%" height="100%"> 
     <scene>
         <Environment frustumCulling='false'></Environment>
-        <Viewpoint position="0 0 5" zNear="0.01" zFar="10000"></Viewpoint>
+        <Viewpoint id="vp" position="0 0 5" zNear="0.01" zFar="10000"></Viewpoint>
         <navigationInfo id="head" headlight='true' type='"EXAMINE"'>  </navigationInfo> 
         <Transform DEF="model" rotation="0 1 0 0" id="gltf">
             <!-- <ExternalShape id="exshape" url="https://cdn.rawgit.com/cx20/gltf-test/master/sampleModels/Duck/glTF-Binary/Duck.glb"></ExternalShape> -->

--- a/examples/x3dom/index.html
+++ b/examples/x3dom/index.html
@@ -23,7 +23,7 @@
         <Transform DEF="model" rotation="0 1 0 0" id="gltf">
             <!-- <ExternalShape id="exshape" url="https://cdn.rawgit.com/cx20/gltf-test/master/sampleModels/Duck/glTF-Binary/Duck.glb"></ExternalShape> -->
         </Transform>                
-        <timeSensor DEF="time" cycleInterval="20" loop="true"></timeSensor>
+        <timeSensor DEF="time" cycleInterval="40" loop="true"></timeSensor>
         <OrientationInterpolator DEF="move" key="0 0.5 1" keyValue="0 1 0 0, 0 1 0 3.14, 0 1 0 6.28"/>
         <Route fromNode="time" fromField ="fraction_changed" toNode="move" toField="set_fraction"></Route>
         <Route fromNode="move" fromField ="value_changed" toNode="model" toField="rotation"></Route>

--- a/examples/x3dom/index.html
+++ b/examples/x3dom/index.html
@@ -18,7 +18,8 @@
 
 <x3d id="x3d" width="100%" height="100%"> 
     <scene>
-        <Viewpoint position="0 0 5" zNear="0.01" zFar="1000"></Viewpoint>
+        <Environment frustumCulling='false'></Environment>
+        <Viewpoint position="0 0 5" zNear="0.01" zFar="10000"></Viewpoint>
         <navigationInfo id="head" headlight='true' type='"EXAMINE"'>  </navigationInfo> 
         <Transform DEF="model" rotation="0 1 0 0" id="gltf">
             <!-- <ExternalShape id="exshape" url="https://cdn.rawgit.com/cx20/gltf-test/master/sampleModels/Duck/glTF-Binary/Duck.glb"></ExternalShape> -->

--- a/examples/x3dom/index.html
+++ b/examples/x3dom/index.html
@@ -14,8 +14,7 @@
 
 <!-- x3dom.debug.js 1.7.3-dev -->
 <script src="../../libs/x3dom/1.7.3dev/x3dom.debug.js"></script>
-<script src="https://rawgit.com/andreasplesch/41f29833c4bbe2e638b3acae0d49f160/raw/09d2d97243c89515ff2fcc7aeebce8f763cbc34c/x3dom_glTFfixer.user.js"></script>
-
+<script src="https://rawgit.com/andreasplesch/41f29833c4bbe2e638b3acae0d49f160/raw/526d0bb4fd8b5640d1082b4b8b7c44fa5a917cea/x3dom_glTFfixer.user.js"></script>
 <x3d id="x3d" width="100%" height="100%"> 
     <scene>
         <Environment frustumCulling='false'></Environment>

--- a/examples/x3dom/index.html
+++ b/examples/x3dom/index.html
@@ -24,7 +24,7 @@
             <!-- <ExternalShape id="exshape" url="https://cdn.rawgit.com/cx20/gltf-test/master/sampleModels/Duck/glTF-Binary/Duck.glb"></ExternalShape> -->
         </Transform>                
         <timeSensor DEF="time" cycleInterval="40" loop="true"></timeSensor>
-        <OrientationInterpolator DEF="move" key="0 0.5 1" keyValue="0 1 0 0, 0 1 0 3.14, 0 1 0 6.28"/>
+        <OrientationInterpolator DEF="move" key="0 0.5 1" keyValue="0 1 0 0, 0 1 0 3.14, 0 1 0 6.28"></OrientationInterpolator>
         <Route fromNode="time" fromField ="fraction_changed" toNode="move" toField="set_fraction"></Route>
         <Route fromNode="move" fromField ="value_changed" toNode="model" toField="rotation"></Route>
     </scene> 

--- a/examples/x3dom/index.js
+++ b/examples/x3dom/index.js
@@ -14,7 +14,11 @@ document.onload = function () {
     shape.attr({scale: scale + " " + scale + " " + scale});
     if (modelInfo.name == 'GearboxAssy') {
         document.querySelector('timesensor').remove();
-        shape.attr({translation: "-159.20 -17.02 -3.21"});
+        //shape.attr({translation: "-159.20 -17.02 -3.21"});
+        var vp = $("#vp");
+        vp.attr({fieldofview: "0.263245"});
+        vp.attr({position: "207.615 53.3281 51.6212"});
+        vp.attr({orientation: "-0.5035214059784457 0.8384312102757996 0.20856485647622058 0.9177268588403985"});
     }
     shape.append("<ExternalShape id='exshape' url='../../" + modelInfo.category + "/" + modelInfo.path + "' />");
 }

--- a/examples/x3dom/index.js
+++ b/examples/x3dom/index.js
@@ -18,6 +18,7 @@ document.onload = function () {
         var vp = $("#vp");
         vp.attr({fieldofview: "0.263245"});
         vp.attr({position: "207.615 53.3281 51.6212"});
+        //from decomposition of camera node transform matrix
         vp.attr({orientation: "-0.5035214059784457 0.8384312102757996 0.20856485647622058 0.9177268588403985"});
         vp.attr({centerofrotation: "159.20 17.02 3.21"});
     }

--- a/examples/x3dom/index.js
+++ b/examples/x3dom/index.js
@@ -12,6 +12,9 @@ document.onload = function () {
     var shape = $("#gltf");
     var scale = modelInfo.scale;
     shape.attr({scale: scale + " " + scale + " " + scale});
-    if (modelInfo.name == 'GearboxAssy') {document.querySelector('timesensor').remove();}
+    if (modelInfo.name == 'GearboxAssy') {
+        document.querySelector('timesensor').remove();
+        shape.attr({translation: "-159.20 -17.02 -3.21"});
+    }
     shape.append("<ExternalShape id='exshape' url='../../" + modelInfo.category + "/" + modelInfo.path + "' />");
 }

--- a/examples/x3dom/index.js
+++ b/examples/x3dom/index.js
@@ -19,7 +19,7 @@ document.onload = function () {
         vp.attr({fieldofview: "0.263245"});
         vp.attr({position: "207.615 53.3281 51.6212"});
         vp.attr({orientation: "-0.5035214059784457 0.8384312102757996 0.20856485647622058 0.9177268588403985"});
-        vp.attr({centerofrotation: "-159.20 -17.02 -3.21"});
+        vp.attr({centerofrotation: "159.20 17.02 3.21"});
     }
     shape.append("<ExternalShape id='exshape' url='../../" + modelInfo.category + "/" + modelInfo.path + "' />");
 }

--- a/examples/x3dom/index.js
+++ b/examples/x3dom/index.js
@@ -12,5 +12,6 @@ document.onload = function () {
     var shape = $("#gltf");
     var scale = modelInfo.scale;
     shape.attr({scale: scale + " " + scale + " " + scale});
+    if (modelInfo.name == 'GearboxAssy') {document.querySelector('timesensor').remove();}
     shape.append("<ExternalShape id='exshape' url='../../" + modelInfo.category + "/" + modelInfo.path + "' />");
 }

--- a/examples/x3dom/index.js
+++ b/examples/x3dom/index.js
@@ -19,6 +19,7 @@ document.onload = function () {
         vp.attr({fieldofview: "0.263245"});
         vp.attr({position: "207.615 53.3281 51.6212"});
         vp.attr({orientation: "-0.5035214059784457 0.8384312102757996 0.20856485647622058 0.9177268588403985"});
+        vp.attr({centerofrotation: "-159.20 -17.02 -3.21"});
     }
     shape.append("<ExternalShape id='exshape' url='../../" + modelInfo.category + "/" + modelInfo.path + "' />");
 }

--- a/libs/x3dom/1.7.3dev/x3dom_glTFfixer.user.js
+++ b/libs/x3dom/1.7.3dev/x3dom_glTFfixer.user.js
@@ -1,0 +1,226 @@
+// ==UserScript==
+// @name        glTFTransformFixer
+// @namespace   aplesch
+// @description use glTF node transforms for meshes
+// @version     0.34
+// @include     *
+// @grant       none
+// ==/UserScript==
+
+//glTFLoader.js
+
+x3dom.glTF.glTFLoader.prototype.updateScene = function(shape, shaderProgram, gl, scene)
+{
+    var nodes = scene["nodes"];
+
+    for(var i = 0; i<nodes.length;++i)
+    {
+        var nodeID = nodes[i];
+        var worldTransform = new x3dom.fields.SFMatrix4f(); // identity
+        this.traverseNode(shape, shaderProgram, gl, this.scene.nodes[nodeID], worldTransform);
+    }
+};
+
+x3dom.glTF.glTFLoader.prototype.getTransform = function (node) {
+    var transform = new x3dom.fields.SFMatrix4f();// start with identity
+    if ( node.matrix ) {
+        transform.setFromArray(node.matrix);
+        return transform;
+    }
+    if ( node.scale && node.scale.length == 3) {
+        var s = node.scale;
+        transform.setScale(new x3dom.fields.SFVec3f(s[0], s[1], s[2]));
+    }
+    if ( node.rotation && node.rotation.length == 4) {
+        var r = node.rotation;
+        var rotationMatrix = new x3dom.fields.SFMatrix4f();
+        rotationMatrix.setRotate(
+            new x3dom.fields.Quaternion(r[0], r[1], r[2], r[3]));
+        transform = rotationMatrix.mult(transform);
+    }
+    if ( node.translation && node.translation.length == 3 ) {
+        var t = node.translation;
+        var translationMatrix = x3dom.fields.SFMatrix4f.translation(
+            new x3dom.fields.SFVec3f(t[0], t[1], t[2]));
+        transform = translationMatrix.mult(transform);
+    }
+    return transform;
+};
+
+x3dom.glTF.glTFLoader.prototype.traverseNode = function(shape, shaderProgram, gl, node, transform)
+{
+    var worldTransform = transform.mult(this.getTransform(node));
+    var children = node["children"];
+    if(children != null)
+        for(var i = 0; i<children.length;++i)
+        {
+            var childID = children[i];
+            this.traverseNode(shape, shaderProgram, gl, this.scene.nodes[childID], worldTransform);
+        }
+
+    var meshes = node["meshes"];
+    if(meshes != null && meshes.length > 0)
+        for (var i = 0; i < meshes.length; ++i) {
+            var meshID = meshes[i];
+            //if (this.loaded.meshes[meshID] == null)
+            {
+                this.updateMesh(shape, shaderProgram, gl, this.scene.meshes[meshID], worldTransform);
+                this.loaded.meshes[meshID] = 1;
+            }
+        }
+};
+
+x3dom.glTF.glTFLoader.prototype.updateMesh = function(shape, shaderProgram, gl, mesh, worldTransform)
+{
+    var primitives = mesh["primitives"];
+    for(var i = 0; i<primitives.length; ++i){
+        this.loadglTFMesh(shape, shaderProgram, gl, primitives[i], worldTransform);
+    }
+};
+
+x3dom.glTF.glTFLoader.prototype.loadglTFMesh =  function(shape, shaderProgram, gl, primitive, worldTransform)
+{
+    "use strict";
+
+    var mesh = new x3dom.glTF.glTFMesh();
+
+    mesh.primitiveType = primitive["mode"];
+
+    var indexed = (primitive.indices != null && primitive.indices != "");
+
+    if(indexed == true){
+        var indicesAccessor = this.scene.accessors[primitive.indices];
+
+        mesh.buffers[glTF_BUFFER_IDX.INDEX] = {};
+        mesh.buffers[glTF_BUFFER_IDX.INDEX].offset = indicesAccessor["byteOffset"];
+        mesh.buffers[glTF_BUFFER_IDX.INDEX].type =  indicesAccessor["componentType"];
+        mesh.buffers[glTF_BUFFER_IDX.INDEX].idx = this.loaded.bufferViews[indicesAccessor["bufferView"]];
+
+        mesh.drawCount = indicesAccessor["count"];
+        this._mesh._numFaces += indicesAccessor["count"] / 3;
+    }
+
+    var attributes = primitive["attributes"];
+
+    for (var attributeID in attributes)
+    {
+        var accessorName = attributes[attributeID];
+        var accessor = this.scene.accessors[accessorName];
+
+        var idx = null;
+
+        //the current renderer does not support generic vertex attributes, so simply look for useable cases
+        switch (attributeID)
+        {
+            case "POSITION":
+                idx = glTF_BUFFER_IDX.POSITION;
+
+                //for non-indexed rendering, we assume that all attributes have the same count
+                if (indexed == false)
+                {
+                    mesh.drawCount = accessor["count"];
+                    this._mesh._numFaces += accessor["count"] / 3;
+                }
+                this._mesh.numCoords += accessor["count"];
+                break;
+
+            case "NORMAL":
+                idx = glTF_BUFFER_IDX.NORMAL;
+                break;
+
+            case "TEXCOORD_0":
+                idx = glTF_BUFFER_IDX.TEXCOORD;
+                break;
+
+            case "COLOR":
+                idx = glTF_BUFFER_IDX.COLOR;
+                break;
+        }
+
+        if(idx != null){
+            mesh.buffers[idx] = {};
+            mesh.buffers[idx].idx = this.loaded.bufferViews[accessor["bufferView"]];
+            mesh.buffers[idx].offset = accessor["byteOffset"];
+            mesh.buffers[idx].stride = accessor["byteStride"];
+
+            mesh.buffers[idx].type = accessor["componentType"];
+            mesh.buffers[idx].numComponents = this.getNumComponentsForType(accessor["type"]);
+        }
+    }
+
+    this.loaded.meshCount += 1;
+
+    shape._dirty.shader = true;
+    shape._nameSpace.doc.needRender = true;
+    x3dom.BinaryContainerLoader.checkError(gl);
+
+    if(primitive.material != null && !this.meshOnly) {
+        mesh.material = this.loadMaterial(gl, this.scene.materials[primitive.material]);
+        mesh.material.worldTransform = worldTransform;
+    }
+
+    if(shape.meshes == null)
+        shape.meshes = [];
+    shape.meshes.push(mesh);
+};
+
+
+
+
+// glTFContainer.js
+
+x3dom.glTF.glTFMaterial.prototype.updateTransforms = function(shaderParameter)
+{
+    function glMultMatrix4 (gl, m) {
+        var glM = new x3dom.fields.SFMatrix4f();
+        glM.setFromArray(gl);
+        return glM.mult(m).toGL(); //optimize by multiplying gl matrixes directly
+    }
+    
+    if(this.program !== null)
+    {
+        this.program.bind();
+
+        for(var key in this.semanticMapping){
+            if(!this.semanticMapping.hasOwnProperty(key))continue;
+
+            var mapping = this.semanticMapping[key];
+
+            switch(mapping){
+                case "modelViewMatrix":
+                    this.program[key] = glMultMatrix4(shaderParameter.modelViewMatrix, this.worldTransform);
+                    break;
+                case "viewMatrix":
+                    this.program[key] = shaderParameter.viewMatrix;
+                    break;
+                case "modelViewInverseTransposeMatrix":
+                    var mat = shaderParameter.normalMatrix;
+                    //not sure how to factor in worldTransform
+                    //modelViewMatrix * worldTransform . inverse . transpose . toGL ?
+
+                    var model_view_inv_gl =
+                        [mat[0], mat[1], mat[2],
+                            mat[4],mat[5],mat[6],
+                            mat[8],mat[9],mat[10]];
+
+                    this.program[key] = model_view_inv_gl;
+                    break;
+                case "modelViewInverseMatrix":
+                    // not sure; perhaps work with worldTransform.inverse
+                    this.program[key] = shaderParameter.modelViewMatrixInverse;
+                    break;
+                case "modelViewProjectionMatrix":
+                    this.program[key] = glMultMatrix4(shaderParameter.modelViewProjectionMatrix, this.worldTransform);
+                    break;
+                case "modelMatrix":
+                    this.program[key] = glMultMatrix4(shaderParameter.model, this.worldTransform);
+                    break;
+                case "projectionMatrix":
+                    this.program[key] = shaderParameter.projectionMatrix;
+                    break;
+                default:
+                    break;
+            }
+        }
+    }
+};


### PR DESCRIPTION
This PR uses the modifications discussed in https://github.com/x3dom/x3dom/issues/709 to improve the x3dom binary-gltf loader. With it, the scenes with a node transform hierarchy are loaded correctly.

In addition, the rotation speed is slowed down and the GearboxAssy example gets special treatment similar to the other loaders. True to the gltf, in this example the position and orientation of the camera is adjusted to reflect exactly the gltf, and the center of user rotation is set to the center of the model.

Here are the examples in my fork with the PR applied:
https://andreasplesch.github.io/gltf-test/

If and when the gltf-loader modifications are incorporated into x3dom-dev this PR becomes obsolete.