### PR TITLE
Apply KHR_materials_unlit fix from VSCode.

### DIFF
--- a/examples/threejs/index.js
+++ b/examples/threejs/index.js
@@ -106,9 +106,15 @@ function init() {
 
         var envMap = getEnvMap();
         object.traverse( function( node ) {
-            if ( node.material ) {
-                node.material.envMap = envMap;
-                node.material.needsUpdate = true;
+            if ( node.isMesh ) {
+                var materials = Array.isArray( node.material ) ? node.material : [ node.material ];
+                materials.forEach( function( material ) {
+                    // MeshBasicMaterial means that KHR_materials_unlit is set, so reflections are not needed.
+                    if ( 'envMap' in material && !material.isMeshBasicMaterial ) {
+                        material.envMap = envMap;
+                        material.needsUpdate = true;
+                    }
+                } );
             }
         } );
         scene.background = envMap;


### PR DESCRIPTION
This is a copy of the code changes from here: https://github.com/AnalyticalGraphicsInc/gltf-vscode/pull/144

Without it, `KHR_materials_unlit` will look mirror-shiny reflective in Three.js.  It's cool but it's not the intent of that particular extension.