### PR TITLE
Add flag to play all animations at once.

### DIFF
--- a/examples/babylonjs/index.js
+++ b/examples/babylonjs/index.js
@@ -44,9 +44,9 @@ var createScene = function(engine) {
     var guiBoundingBox = gui.add(window, 'BOUNDING_BOX').name('Bounding Box');
     var guiDebug = gui.add(window, 'DEBUG').name('Debug');
 
-    BABYLON.SceneLoader.OnPluginActivatedObservable.add(function (plugin) {
+    BABYLON.SceneLoader.OnPluginActivatedObservable.addOnce(function (plugin) {
         plugin.animationStartMode = modelInfo.allAnimations ? BABYLON.GLTFLoaderAnimationStartMode.ALL : BABYLON.GLTFLoaderAnimationStartMode.FIRST;
-    }, undefined, undefined, undefined, true);
+    });
 
     var loader = BABYLON.SceneLoader.Load(base, file, engine, function(newScene) {
 

--- a/examples/babylonjs/index.js
+++ b/examples/babylonjs/index.js
@@ -44,6 +44,10 @@ var createScene = function(engine) {
     var guiBoundingBox = gui.add(window, 'BOUNDING_BOX').name('Bounding Box');
     var guiDebug = gui.add(window, 'DEBUG').name('Debug');
 
+    BABYLON.SceneLoader.OnPluginActivatedObservable.add(function (plugin) {
+        plugin.animationStartMode = modelInfo.allAnimations ? BABYLON.GLTFLoaderAnimationStartMode.ALL : BABYLON.GLTFLoaderAnimationStartMode.FIRST;
+    }, undefined, undefined, undefined, true);
+
     var loader = BABYLON.SceneLoader.Load(base, file, engine, function(newScene) {
 
         scene = newScene;
@@ -62,7 +66,7 @@ var createScene = function(engine) {
         camera.attachControl(canvas, false, false);
         camera.wheelDeltaPercentage = 0.005;
         scene.activeCamera = camera;
-        
+
         var light1 = new BABYLON.DirectionalLight("dir01", new BABYLON.Vector3(0.0, -1.0, 0.5), scene);
         var light2 = new BABYLON.DirectionalLight("dir02", new BABYLON.Vector3(-0.5, -0.5, -0.5), scene);
 
@@ -102,9 +106,9 @@ var createScene = function(engine) {
             scene.render();
         });
     });
-    
+
     return scene;
-}
+};
 
 var canvas = document.querySelector("#renderCanvas");
 var engine = new BABYLON.Engine(canvas, true);

--- a/tutorialModels/model-index.js
+++ b/tutorialModels/model-index.js
@@ -13,7 +13,7 @@ TutorialModelIndex.List = [
     //{category:'tutorialModels', name:'SimpleTexture', scale:1.0},
     {category:'tutorialModels', name:'Cameras', scale:1.0},
     //{category:'tutorialModels', name:'SimpleSkin', scale:1.0},
-    {category:'tutorialModels', name:'InterpolationTest', scale:1.0},
+    {category:'tutorialModels', name:'InterpolationTest', scale:1.0, allAnimations:true},  // Play all model animations at the same time
 ];
 
 TutorialModelIndex.HasGifScreenshot = [ // List of only models that have *.gif screenshots (as opposed to *.png)
@@ -50,14 +50,16 @@ TutorialModelIndex.getModelInfoCollection = function() {
         var category = TutorialModelIndex.List[i].category;
         var name = TutorialModelIndex.List[i].name;
         var scale = TutorialModelIndex.List[i].scale;
+        var allAnimations = TutorialModelIndex.List[i].allAnimations;
         modelInfoCollection[name] = {
             category: category,
             name: name,
-            scale: scale
+            scale: scale,
+            allAnimations: allAnimations
         };
     }
     return modelInfoCollection;
-}
+};
 
 TutorialModelIndex.getCurrentModel = function() {
     var modelInfoCollection = TutorialModelIndex.getModelInfoCollection();


### PR DESCRIPTION
This adds a new optional flag `allAnimations` to the model index, which indicates that the sample model needs all of its animations to run at the same time.  The InterpolationTest model is the first one to use the new flag.

Babylon's default behavior is to play only the first animation by default, not all animations at once.  This is because a game model might have overlapping animations like "walk", "jump", "run", etc.  But models like InterpolationTest have separate animation targets and are intended to run all at the same time.

This should allow Babylon to pass InterpolationTest.  In the future there may be more models that need to indicate "all" vs. "first", and other example viewers may need to respect this flag (currently most of them do "all" by default).