### PR TITLE
Fix KHR_physics extension loading and box shape default size

### DIFF
--- a/examples/khronos-gltf-rv/index.js
+++ b/examples/khronos-gltf-rv/index.js
@@ -378,10 +378,11 @@ function createImplicitShapeFromDef(shapeDef, worldScale, motionDef, matDef) {
             checkResult(HK.HP_Shape_SetDensity(shapeId, density), 'HP_Shape_SetDensity');
         }
     } else if (shapeDef.box) {
+        const boxSize = shapeDef.box.size ?? [1, 1, 1];
         const size = [
-            Math.abs(shapeDef.box.size[0] * worldScale[0]),
-            Math.abs(shapeDef.box.size[1] * worldScale[1]),
-            Math.abs(shapeDef.box.size[2] * worldScale[2]),
+            Math.abs(boxSize[0] * worldScale[0]),
+            Math.abs(boxSize[1] * worldScale[1]),
+            Math.abs(boxSize[2] * worldScale[2]),
         ];
         const created = HK.HP_Shape_CreateBox([0, 0, 0], IDENTITY_QUATERNION, size);
         checkResult(created[0], 'HP_Shape_CreateBox');

--- a/libs/khronos-gltf-rv/1.1.0/gltf-viewer.module.js
+++ b/libs/khronos-gltf-rv/1.1.0/gltf-viewer.module.js
@@ -18956,6 +18956,8 @@ const allowedExtensions = [
     "KHR_texture_transform",
     "KHR_xmp_json_ld",
     "EXT_texture_webp",
+    "KHR_implicit_shapes",
+    "KHR_physics_rigid_bodies",
 ];
 
 class glTF extends GltfObject


### PR DESCRIPTION
Fixes two issues in the khronos-gltf-rv physics integration.

gltf-viewer.module.js: Add KHR_implicit_shapes and KHR_physics_rigid_bodies to allowedExtensions. Models that list these in extensionsRequired were throwing 'Unsupported extension' errors.

index.js: Fix crash in createImplicitShapeFromDef when box shape omits the optional size property. shapeDef.box.size can be undefined per the KHR_implicit_shapes spec (default is [1, 1, 1]), causing TypeError: Cannot read properties of undefined (reading 0).