### PR TITLE
fix(threejs): correct KHR_physics_rigid_bodies scale drift and material combine rules

### DIFF
--- a/examples/threejs/index.js
+++ b/examples/threejs/index.js
@@ -566,6 +566,21 @@ function buildColliderDesc(gltfJson, threeNode, geomDef, worldScale, matDef) {
     if (matDef) {
         if (matDef.staticFriction !== undefined) desc.setFriction(matDef.staticFriction);
         if (matDef.restitution    !== undefined) desc.setRestitution(matDef.restitution);
+        // KHR_physics_rigid_bodies combine rules: "average" | "minimum" | "maximum" | "multiply"
+        // Rapier defaults to Average, so explicitly forwarding the rule is required for
+        // assets like RigidBodies_Materials_01 where two spheres differ only by combine.
+        const combineMap = {
+            average:  RAPIER.CoefficientCombineRule.Average,
+            minimum:  RAPIER.CoefficientCombineRule.Min,
+            maximum:  RAPIER.CoefficientCombineRule.Max,
+            multiply: RAPIER.CoefficientCombineRule.Multiply,
+        };
+        if (matDef.frictionCombine && combineMap[matDef.frictionCombine] !== undefined) {
+            desc.setFrictionCombineRule(combineMap[matDef.frictionCombine]);
+        }
+        if (matDef.restitutionCombine && combineMap[matDef.restitutionCombine] !== undefined) {
+            desc.setRestitutionCombineRule(combineMap[matDef.restitutionCombine]);
+        }
     }
     return desc;
 }
@@ -716,11 +731,15 @@ function physicsStep(delta) {
         const parent = entry.node.parent;
         if (parent) {
             parent.updateWorldMatrix(true, false);
-            const invParent = parent.matrixWorld.clone().invert();
-            const localMat  = new THREE.Matrix4()
-                .compose(worldPos, worldQuat, entry.node.scale.clone());
-            localMat.premultiply(invParent);
-            localMat.decompose(entry.node.position, entry.node.quaternion, entry.node.scale);
+            // Convert world transform to parent-local without touching node.scale.
+            // Decomposing a (compose * invParent) matrix would feed node.scale back
+            // into itself when the parent has non-identity scale, causing the local
+            // scale to drift exponentially every frame.
+            const invParentMat = parent.matrixWorld.clone().invert();
+            entry.node.position.copy(worldPos).applyMatrix4(invParentMat);
+            const parentWorldQuat = new THREE.Quaternion();
+            parent.getWorldQuaternion(parentWorldQuat);
+            entry.node.quaternion.copy(parentWorldQuat).invert().multiply(worldQuat);
         } else {
             entry.node.position.copy(worldPos);
             entry.node.quaternion.copy(worldQuat);


### PR DESCRIPTION
Fixes two issues that prevented [`RigidBodies_Materials_01.gltf`](https://github.com/eoineoineoin/glTF_Physics/blob/master/tests/RigidBodies_Materials/RigidBodies_Materials_01.gltf) from simulating correctly in the Three.js viewer.

## 1. Scale drift

`physicsStep` was building a local matrix via `compose(worldPos, worldQuat, node.scale)` and decomposing the result back into `node.position` / `quaternion` / `scale`. When the gltf root carries a non-identity scale (e.g. `?scale=0.5` on the viewer URL), the compose-then-decompose round trip feeds `node.scale` back into itself multiplied by the inverse parent scale every frame, so the local scale doubles each step (1, 2, 4, 8, ...). Bodies grow exponentially and disappear within a few frames.

The fix converts the world transform to parent-local using `applyMatrix4` and quaternion math directly, leaving `node.scale` untouched.

## 2. Missing combine rules

`buildColliderDesc` forwarded restitution/friction values but not the combine rule. Rapier defaults to `Average`, so the two spheres in this asset that differ only by `restitutionCombine` (`minimum` vs `maximum`) bounced identically.

The fix maps the KHR_physics_rigid_bodies combine strings (`average` / `minimum` / `maximum` / `multiply`) to Rapier's `CoefficientCombineRule` and applies them via `setFrictionCombineRule` / `setRestitutionCombineRule`.

## Verification

URL: `examples/threejs/index.html?url=.../RigidBodies_Materials_01.gltf&scale=0.5`

- Both spheres now correctly land on the static box (no exponential growth).
- The `restitutionCombine: maximum` sphere bounces, while the `restitutionCombine: minimum` sphere does not, matching the intended bowling-ball vs basketball behavior.