### PR TITLE
Delay glTF Physics simulation until resources are loaded (three.js / WebGPU)

### DIFF
--- a/examples/threejs/index.js
+++ b/examples/threejs/index.js
@@ -89,7 +89,16 @@ const RESET_Y_THRESHOLD = -20;
 let RAPIER = await import(RAPIER_PATH);
 await RAPIER.init();
 let physicsWorld = null;
+let physicsReady = false;
+let envReady = false;
 const dynamicBodies = [];
+
+function tryStartPhysics() {
+    if (physicsReady) return;
+    if (!physicsWorld) return;
+    if (!envReady) return;
+    setTimeout(function() { physicsReady = true; }, 200);
+}
 
 init();
 animate();
@@ -243,6 +252,11 @@ function init() {
                 renderer.toneMappingExposure = Math.pow(params.exposure, 4.0);
                 composer.addPass( renderScene );
                 composer.addPass( bloomPass );
+
+                // Resources are now loaded. Allow physics to start after a short delay
+                // so the first rendered frame shows the scene before bodies start moving.
+                envReady = true;
+                tryStartPhysics();
             } );
 
         scene.add(object);
@@ -712,10 +726,21 @@ function initPhysics(gltfJson, threeNodes) {
         }
     }
     console.log('KHR physics initialized:', dynamicBodies.length, 'dynamic bodies');
+    // Try to start physics now (will only proceed if env is also ready).
+    tryStartPhysics();
+    // Fallback: in case the HDR environment fails to load, still start physics
+    // so the simulation does not stay frozen forever.
+    setTimeout(function() {
+        if (!physicsReady) {
+            console.log('[Physics] Fallback start (resources not ready within 5s)');
+            physicsReady = true;
+        }
+    }, 5000);
 }
 
 function physicsStep(delta) {
     if (!physicsWorld) return;
+    if (!physicsReady) return;
     physicsWorld.timestep = Math.min(delta, 1 / 30);
     physicsWorld.step();
     for (const entry of dynamicBodies) {

--- a/examples/threejs_webgpu/index.js
+++ b/examples/threejs_webgpu/index.js
@@ -50,6 +50,15 @@ const RAPIER_PATH = 'https://cdn.skypack.dev/@dimforge/rapier3d-compat@0.17.3';
 const RESET_Y_THRESHOLD = -20;
 let RAPIER = null;
 let physicsWorld = null;
+let physicsReady = false;
+let envReady = false;
+
+function tryStartPhysics() {
+    if (physicsReady) return;
+    if (!physicsWorld) return;
+    if (!envReady) return;
+    setTimeout(function() { physicsReady = true; }, 200);
+}
 const dynamicBodies = [];
 
 const clock = new THREE.Clock();
@@ -280,10 +289,18 @@ async function init() {
 
             updateEnvironment();
 
+            // Resources are now loaded. Allow physics to start after a short delay
+            // so the first rendered frame shows the scene before bodies start moving.
+            envReady = true;
+            tryStartPhysics();
+
         }, undefined, function () {
 
             console.warn('Failed to load local HDR environment map. Rendering without environment map.');
             updateEnvironment();
+
+            envReady = true;
+            tryStartPhysics();
 
         } );
 
@@ -661,10 +678,21 @@ function initPhysics(gltfJson, threeNodes) {
         }
     }
     console.log('KHR physics initialized:', dynamicBodies.length, 'dynamic bodies');
+    // Try to start physics now (will only proceed if env is also ready).
+    tryStartPhysics();
+    // Fallback: in case the HDR environment fails to load, still start physics
+    // so the simulation does not stay frozen forever.
+    setTimeout(function() {
+        if (!physicsReady) {
+            console.log('[Physics] Fallback start (resources not ready within 5s)');
+            physicsReady = true;
+        }
+    }, 5000);
 }
 
 function physicsStep(delta) {
     if (!physicsWorld) return;
+    if (!physicsReady) return;
     physicsWorld.timestep = Math.min(delta, 1 / 30);
     physicsWorld.step();
     for (const entry of dynamicBodies) {


### PR DESCRIPTION
## Problem

When loading a glTF Physics scene in the three.js examples, the Rapier simulation started during scene loading. Dynamic bodies (e.g. a small ball falling onto a larger one) were already moving before the HDR environment map and lighting were applied, so users briefly saw the model dark and partially settled.

Reproduction:
http://127.0.0.1:5500/examples/threejs/index.html?url=https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/tests/RigidBodies_ColliderTypeMatrix/RigidBodies_ColliderTypeMatrix_00.gltf&scale=0.5

## Fix

Gate `physicsStep` on a `physicsReady` flag. The flag is set ~200 ms after **both**:

- the physics world is initialized (`initPhysics` after glTF load), and
- the HDR environment map finishes loading (`HDRCubeTextureLoader` for WebGL, `HDRLoader` for WebGPU), or its error callback fires.

A shared `tryStartPhysics()` helper checks both `physicsWorld` and `envReady`, so the simulation starts at the correct moment regardless of which load completes first. A 5 s fallback ensures the simulation eventually starts even if the HDR callback never fires.

Applied to both:
- `examples/threejs/index.js` (WebGL)
- `examples/threejs_webgpu/index.js` (WebGPU)