### PR TITLE
Support KHR_physics_rigid_bodies collisionFilters in three.js examples

### DIFF
--- a/examples/threejs/index.js
+++ b/examples/threejs/index.js
@@ -634,12 +634,61 @@ function computeApproxInertia(mass, geomDef, gltfJson, worldScale) {
     return { x: 0.1 * mass, y: 0.1 * mass, z: 0.1 * mass };
 }
 
+// ---- KHR_physics_rigid_bodies collision filter ----
+// Build a table mapping each glTF collisionFilter index to a Rapier collision-groups u32.
+// Rapier format: high 16 bits = membership groups, low 16 bits = filter mask.
+// Two colliders collide iff (A.mem & B.filter) != 0 AND (B.mem & A.filter) != 0.
+function buildCollisionFilterTable(gltfJson) {
+    const filters = gltfJson.extensions?.KHR_physics_rigid_bodies?.collisionFilters ?? [];
+    if (filters.length === 0) return [];
+    const systemBit = new Map();
+    let nextBit = 0;
+    function bitFor(name) {
+        if (!systemBit.has(name)) {
+            if (nextBit >= 16) {
+                console.warn('[Physics] Too many collision systems (>16), ignoring:', name);
+                systemBit.set(name, 0);
+            } else {
+                systemBit.set(name, 1 << nextBit);
+                nextBit++;
+            }
+        }
+        return systemBit.get(name);
+    }
+    const ALL = 0xFFFF;
+    return filters.map(function (f) {
+        let membership = 0;
+        for (const n of (f.collisionSystems ?? [])) membership |= bitFor(n);
+        let filterMask;
+        if (Array.isArray(f.collideWithSystems)) {
+            filterMask = 0;
+            for (const n of f.collideWithSystems) filterMask |= bitFor(n);
+        } else if (Array.isArray(f.notCollideWithSystems)) {
+            let mask = 0;
+            for (const n of f.notCollideWithSystems) mask |= bitFor(n);
+            filterMask = ALL & ~mask;
+        } else {
+            filterMask = ALL;
+        }
+        return (((membership & ALL) << 16) | (filterMask & ALL)) >>> 0;
+    });
+}
+
+function applyCollisionFilterToDesc(desc, colliderDef, table) {
+    const idx = colliderDef?.collisionFilter;
+    if (typeof idx !== 'number') return;
+    const groups = table[idx];
+    if (groups === undefined) return;
+    desc.setCollisionGroups(groups);
+}
+
 function initPhysics(gltfJson, threeNodes) {
     physicsWorld = new RAPIER.World({ x: 0, y: -9.81, z: 0 });
     dynamicBodies.length = 0;
     const matDefs = gltfJson.extensions?.KHR_physics_rigid_bodies?.physicsMaterials ?? [];
     const nodes   = gltfJson.nodes ?? [];
     const excludedIndices = new Set();
+    const collisionGroupsByFilterIndex = buildCollisionFilterTable(gltfJson);
 
     // --- First pass: compound bodies (motion present, no collider on root) ---
     for (let i = 0; i < nodes.length; i++) {
@@ -677,6 +726,7 @@ function initPhysics(gltfJson, threeNodes) {
             if (!desc) continue;
             desc.setTranslation(localPos.x, localPos.y, localPos.z);
             desc.setRotation({ x: localQuat.x, y: localQuat.y, z: localQuat.z, w: localQuat.w });
+            applyCollisionFilterToDesc(desc, childPhys.collider, collisionGroupsByFilterIndex);
             physicsWorld.createCollider(desc, body);
         }
         if (!isKinematic) {
@@ -711,6 +761,7 @@ function initPhysics(gltfJson, threeNodes) {
         }
         if (motionDef?.restitution !== undefined) desc.setRestitution(motionDef.restitution);
         const body = physicsWorld.createRigidBody(makeRigidBodyDesc(threeNode, motionDef, isKinematic));
+        applyCollisionFilterToDesc(desc, physExt.collider, collisionGroupsByFilterIndex);
         physicsWorld.createCollider(desc, body);
         if (hasCom && motionDef) {
             const [cx, cy, cz] = motionDef.centerOfMass;

--- a/examples/threejs_webgpu/index.js
+++ b/examples/threejs_webgpu/index.js
@@ -586,12 +586,61 @@ function computeApproxInertia(mass, geomDef, gltfJson, worldScale) {
     return { x: 0.1 * mass, y: 0.1 * mass, z: 0.1 * mass };
 }
 
+// ---- KHR_physics_rigid_bodies collision filter ----
+// Build a table mapping each glTF collisionFilter index to a Rapier collision-groups u32.
+// Rapier format: high 16 bits = membership groups, low 16 bits = filter mask.
+// Two colliders collide iff (A.mem & B.filter) != 0 AND (B.mem & A.filter) != 0.
+function buildCollisionFilterTable(gltfJson) {
+    const filters = gltfJson.extensions?.KHR_physics_rigid_bodies?.collisionFilters ?? [];
+    if (filters.length === 0) return [];
+    const systemBit = new Map();
+    let nextBit = 0;
+    function bitFor(name) {
+        if (!systemBit.has(name)) {
+            if (nextBit >= 16) {
+                console.warn('[Physics] Too many collision systems (>16), ignoring:', name);
+                systemBit.set(name, 0);
+            } else {
+                systemBit.set(name, 1 << nextBit);
+                nextBit++;
+            }
+        }
+        return systemBit.get(name);
+    }
+    const ALL = 0xFFFF;
+    return filters.map(function (f) {
+        let membership = 0;
+        for (const n of (f.collisionSystems ?? [])) membership |= bitFor(n);
+        let filterMask;
+        if (Array.isArray(f.collideWithSystems)) {
+            filterMask = 0;
+            for (const n of f.collideWithSystems) filterMask |= bitFor(n);
+        } else if (Array.isArray(f.notCollideWithSystems)) {
+            let mask = 0;
+            for (const n of f.notCollideWithSystems) mask |= bitFor(n);
+            filterMask = ALL & ~mask;
+        } else {
+            filterMask = ALL;
+        }
+        return (((membership & ALL) << 16) | (filterMask & ALL)) >>> 0;
+    });
+}
+
+function applyCollisionFilterToDesc(desc, colliderDef, table) {
+    const idx = colliderDef?.collisionFilter;
+    if (typeof idx !== 'number') return;
+    const groups = table[idx];
+    if (groups === undefined) return;
+    desc.setCollisionGroups(groups);
+}
+
 function initPhysics(gltfJson, threeNodes) {
     physicsWorld = new RAPIER.World({ x: 0, y: -9.81, z: 0 });
     dynamicBodies.length = 0;
     const matDefs = gltfJson.extensions?.KHR_physics_rigid_bodies?.physicsMaterials ?? [];
     const nodes   = gltfJson.nodes ?? [];
     const excludedIndices = new Set();
+    const collisionGroupsByFilterIndex = buildCollisionFilterTable(gltfJson);
 
     // --- First pass: compound bodies (motion present, no collider on root) ---
     for (let i = 0; i < nodes.length; i++) {
@@ -629,6 +678,7 @@ function initPhysics(gltfJson, threeNodes) {
             if (!desc) continue;
             desc.setTranslation(localPos.x, localPos.y, localPos.z);
             desc.setRotation({ x: localQuat.x, y: localQuat.y, z: localQuat.z, w: localQuat.w });
+            applyCollisionFilterToDesc(desc, childPhys.collider, collisionGroupsByFilterIndex);
             physicsWorld.createCollider(desc, body);
         }
         if (!isKinematic) {
@@ -663,6 +713,7 @@ function initPhysics(gltfJson, threeNodes) {
         }
         if (motionDef?.restitution !== undefined) desc.setRestitution(motionDef.restitution);
         const body = physicsWorld.createRigidBody(makeRigidBodyDesc(threeNode, motionDef, isKinematic));
+        applyCollisionFilterToDesc(desc, physExt.collider, collisionGroupsByFilterIndex);
         physicsWorld.createCollider(desc, body);
         if (hasCom && motionDef) {
             const [cx, cy, cz] = motionDef.centerOfMass;


### PR DESCRIPTION
## Problem

The `KHR_physics_rigid_bodies` collisionFilters table was being ignored, so tests such as `RigidBodies_CollisionFilter_02.gltf` did not behave as specified — bodies that should pass through the floor (`collideWithSystems` excluding `StaticGroup`) collided with it, and compound bodies that should partially intersect the floor settled cleanly on top instead.

Reproduction:
http://127.0.0.1:5500/examples/threejs/index.html?url=https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/tests/RigidBodies_CollisionFilter/RigidBodies_CollisionFilter_02.gltf&scale=0.5

## Fix

Map each entry in the top-level `KHR_physics_rigid_bodies.collisionFilters` array to a Rapier `collisionGroups` `u32`:

- High 16 bits = membership groups, derived from `collisionSystems`.
- Low 16 bits = filter mask:
  - `collideWithSystems` (whitelist) → bits for the listed systems.
  - `notCollideWithSystems` (blacklist) → `0xFFFF & ~mask`.
  - Neither specified → `0xFFFF` (collide with all).

System names are assigned bits in first-seen order (max 16, with a console warning if exceeded). The resulting value is applied via `ColliderDesc.setCollisionGroups` before each collider is created, for both compound bodies and single-shape bodies.

Applied to both:
- `examples/threejs/index.js` (WebGL)
- `examples/threejs_webgpu/index.js` (WebGPU)