### PR TITLE
Add Babylon glTF physics export controls

### DIFF
--- a/examples/babylonjs/index.html
+++ b/examples/babylonjs/index.html
@@ -25,6 +25,8 @@
 <script src="../../libs/babylonjs/9.4.1/babylon-gltf-rigid-body-loader.js"></script>
 <!-- babylon.glTF2Serializer.js -->
 <script src="../../libs/babylonjs/9.4.1/babylon.glTF2Serializer.js"></script>
+<!-- glTF Physics Exporter -->
+<script src="https://cx20.github.io/gltf-physics-export/example/babylonjs/gltf-physics-exporter.js"></script>
 <!-- babylon.inspector.js -->
 <script src="../../libs/babylonjs/9.4.1/babylon.inspector.bundle.js"></script>
 <!-- dat.gui.js -->

--- a/examples/babylonjs/index.js
+++ b/examples/babylonjs/index.js
@@ -94,6 +94,29 @@ function getBasename(path) {
     return path.split("/").pop();
 }
 
+function getFileStem(name) {
+    const basename = getBasename(name || "scene");
+    const lastDot = basename.lastIndexOf(".");
+    return lastDot >= 0 ? basename.slice(0, lastDot) : basename;
+}
+
+function getExportName(modelSource, modelInfo, path) {
+    if (modelSource.displayName) {
+        return getFileStem(modelSource.displayName);
+    }
+    if (modelInfo?.name && modelInfo.name !== "Other") {
+        return modelInfo.name;
+    }
+    return getFileStem(path);
+}
+
+function getCaptureUrl(sceneSource) {
+    if (sceneSource.sceneFilename.startsWith("blob:") || sceneSource.sceneFilename.startsWith("data:")) {
+        return sceneSource.sceneFilename;
+    }
+    return sceneSource.rootUrl + sceneSource.sceneFilename;
+}
+
 async function createDroppedModelSource(fileList) {
     const files = Array.from(fileList);
     const modelFile = files.find(function(file) {
@@ -321,6 +344,7 @@ let createScene = function(engine, modelSource) {
     }
     const pluginExtension = getPluginExtension(modelSource, path, modelInfo);
     const sceneSource = splitScenePath(path);
+    const exportName = getExportName(modelSource, modelInfo, path);
 
     // GUI
     let gui = new dat.GUI();
@@ -335,6 +359,17 @@ let createScene = function(engine, modelSource) {
     let guiTonemap = gui.add(params, 'TONEMAP', tonemaps).name('Tonemap');
     let guiDebug = gui.add(params, 'DEBUG').name('Debug');
     let guiPhysicsDebug = gui.add(params, 'PHYSICS_DEBUG').name('Physics Debug');
+    let guiExport = gui.add({
+        exportGLTFPhysics: function() {
+            if (!BABYLON.GLTFPhysicsExport) {
+                console.warn("[glTF Physics Export] Exporter is not loaded.");
+                return;
+            }
+            BABYLON.GLTFPhysicsExport.GLBAsync(scene, exportName).catch(function(error) {
+                console.error("[glTF Physics Export] Export failed:", error);
+            });
+        }
+    }, "exportGLTFPhysics").name("Export glTF Physics");
     let guiVariants = null;
     let guiCameras = null;
 
@@ -368,9 +403,23 @@ let createScene = function(engine, modelSource) {
         engine,
         undefined,
         pluginExtension
-    ).then(function (newScene) {
+    ).then(async function (newScene) {
 
         scene = newScene;
+
+        if (BABYLON.GLTFPhysicsExport) {
+            const captureUrl = getCaptureUrl(sceneSource);
+            if (pluginExtension === ".glb") {
+                try {
+                    await BABYLON.GLTFPhysicsExport.captureLoadedAsync(scene, captureUrl);
+                } catch (error) {
+                    console.warn("[glTF Physics Export] Failed to capture loaded physics extensions:", error);
+                }
+            }
+            BABYLON.GLTFPhysicsExport.snapshot(scene);
+        } else {
+            console.warn("[glTF Physics Export] Exporter is not loaded.");
+        }
 
         // Physics diagnostics
         console.log('[Physics] Scene loaded');

--- a/examples/babylonjs_webgpu/index.html
+++ b/examples/babylonjs_webgpu/index.html
@@ -25,6 +25,8 @@
 <script src="../../libs/babylonjs/9.4.1/babylon-gltf-rigid-body-loader.js"></script>
 <!-- babylon.glTF2Serializer.js -->
 <script src="../../libs/babylonjs/9.4.1/babylon.glTF2Serializer.js"></script>
+<!-- glTF Physics Exporter -->
+<script src="https://cx20.github.io/gltf-physics-export/example/babylonjs/gltf-physics-exporter.js"></script>
 <!-- babylon.inspector.js -->
 <script src="../../libs/babylonjs/9.4.1/babylon.inspector.bundle.js"></script>
 <!-- dat.gui.js -->

--- a/examples/babylonjs_webgpu/index.js
+++ b/examples/babylonjs_webgpu/index.js
@@ -35,6 +35,7 @@ let params = {
     LIGHTS: false,
     BLOOM: true,
     DEBUG: false,
+    PHYSICS_DEBUG: true,
     VARIANT: DEFAULT_NAME,
     CAMERA: DEFAULT_NAME,
     TONEMAP: "None"
@@ -90,6 +91,29 @@ function isExternalUri(uri) {
 
 function getBasename(path) {
     return path.split("/").pop();
+}
+
+function getFileStem(name) {
+    const basename = getBasename(name || "scene");
+    const lastDot = basename.lastIndexOf(".");
+    return lastDot >= 0 ? basename.slice(0, lastDot) : basename;
+}
+
+function getExportName(modelSource, modelInfo, path) {
+    if (modelSource.displayName) {
+        return getFileStem(modelSource.displayName);
+    }
+    if (modelInfo?.name && modelInfo.name !== "Other") {
+        return modelInfo.name;
+    }
+    return getFileStem(path);
+}
+
+function getCaptureUrl(sceneSource) {
+    if (sceneSource.sceneFilename.startsWith("blob:") || sceneSource.sceneFilename.startsWith("data:")) {
+        return sceneSource.sceneFilename;
+    }
+    return sceneSource.rootUrl + sceneSource.sceneFilename;
 }
 
 async function createDroppedModelSource(fileList) {
@@ -291,6 +315,7 @@ let createScene = function(engine, modelSource) {
     }
     const pluginExtension = getPluginExtension(modelSource, path, modelInfo);
     const sceneSource = splitScenePath(path);
+    const exportName = getExportName(modelSource, modelInfo, path);
 
     let gui = new dat.GUI();
     let pipeline = null;
@@ -303,6 +328,18 @@ let createScene = function(engine, modelSource) {
     const tonemaps = ["None", "Standard", "ACES", "PBR Neutral"];
     let guiTonemap = gui.add(params, 'TONEMAP', tonemaps).name('Tonemap');
     let guiDebug = gui.add(params, 'DEBUG').name('Debug');
+    let guiPhysicsDebug = gui.add(params, 'PHYSICS_DEBUG').name('Physics Debug');
+    let guiExport = gui.add({
+        exportGLTFPhysics: function() {
+            if (!BABYLON.GLTFPhysicsExport) {
+                console.warn("[glTF Physics Export] Exporter is not loaded.");
+                return;
+            }
+            BABYLON.GLTFPhysicsExport.GLBAsync(scene, exportName).catch(function(error) {
+                console.error("[glTF Physics Export] Export failed:", error);
+            });
+        }
+    }, "exportGLTFPhysics").name("Export glTF Physics");
     let guiVariants = null;
     let guiCameras = null;
 
@@ -335,8 +372,22 @@ let createScene = function(engine, modelSource) {
         engine,
         undefined,
         pluginExtension
-    ).then(function (newScene) {
+    ).then(async function (newScene) {
         scene = newScene;
+
+        if (BABYLON.GLTFPhysicsExport) {
+            const captureUrl = getCaptureUrl(sceneSource);
+            if (pluginExtension === ".glb") {
+                try {
+                    await BABYLON.GLTFPhysicsExport.captureLoadedAsync(scene, captureUrl);
+                } catch (error) {
+                    console.warn("[glTF Physics Export] Failed to capture loaded physics extensions:", error);
+                }
+            }
+            BABYLON.GLTFPhysicsExport.snapshot(scene);
+        } else {
+            console.warn("[glTF Physics Export] Exporter is not loaded.");
+        }
 
         const physicsEngine = scene.getPhysicsEngine && scene.getPhysicsEngine();
         if (physicsExtensionLoaded && physicsEngine && typeof physicsEngine.setTimeStep === 'function') {
@@ -493,6 +544,27 @@ let createScene = function(engine, modelSource) {
         guiDebug.onChange(function (value) {
             scene.debugLayer.show({embedMode: value});
         });
+
+        let physicsViewer = null;
+        function showPhysicsDebug(value) {
+            if (value) {
+                if (!physicsViewer && BABYLON.PhysicsViewer) {
+                    physicsViewer = new BABYLON.PhysicsViewer(scene);
+                }
+                if (physicsViewer) {
+                    scene.meshes.forEach(function(m) {
+                        if (m.physicsBody) {
+                            try { physicsViewer.showBody(m.physicsBody); } catch(e) {}
+                        }
+                    });
+                }
+            } else if (physicsViewer) {
+                physicsViewer.dispose();
+                physicsViewer = null;
+            }
+        }
+        if (params.PHYSICS_DEBUG) showPhysicsDebug(true);
+        guiPhysicsDebug.onChange(showPhysicsDebug);
 
         scene._viewerGui = gui;
         return scene;


### PR DESCRIPTION
## Summary
- load the glTF Physics exporter in Babylon.js and Babylon.js WebGPU samples
- add dat.GUI export controls that write .glb files via GLTFPhysicsExport
- preserve loaded GLB physics extensions and add Physics Debug support to the WebGPU sample

## Tests
- node --check examples\\babylonjs\\index.js
- node --check examples\\babylonjs_webgpu\\index.js
- git diff --check -- examples\\babylonjs\\index.html examples\\babylonjs\\index.js examples\\babylonjs_webgpu\\index.html examples\\babylonjs_webgpu\\index.js