### PR TITLE
Use tagged glTF load so remote KHR physics round-trips (Babylon.js WebGL/WebGPU)

### DIFF
--- a/examples/babylonjs/index.js
+++ b/examples/babylonjs/index.js
@@ -397,19 +397,45 @@ let createScene = function(engine, modelSource) {
         });
     });
 
-    return BABYLON.SceneLoader.LoadAsync(
-        sceneSource.rootUrl,
-        sceneSource.sceneFilename,
-        engine,
-        undefined,
-        pluginExtension
-    ).then(async function (newScene) {
+    const captureUrl = getCaptureUrl(sceneSource);
+    // Drag-dropped / data-URI models resolve their external buffers and
+    // textures through an in-memory file map that appendTaggedAsync can't
+    // see, so only http(s) sources take the tagged path.
+    const isRemoteSource = !(sceneSource.sceneFilename.startsWith("blob:")
+        || sceneSource.sceneFilename.startsWith("data:"));
+
+    let loadPromise;
+    if (isRemoteSource
+        && BABYLON.GLTFPhysicsExport
+        && typeof BABYLON.GLTFPhysicsExport.appendTaggedAsync === "function") {
+        // Stamp every source node with its index and splice in any missing
+        // top-level physics extension blocks before the loader runs, so
+        // KHR_physics_rigid_bodies round-trips through the exporter even for
+        // nameless / duplicate-named nodes (e.g. the RigidBodies_* tests,
+        // whose nodes are unnamed and whose top-level rigid-bodies block is
+        // omitted). Non-physics models pass through untouched.
+        const taggedScene = new BABYLON.Scene(engine);
+        loadPromise = BABYLON.GLTFPhysicsExport.appendTaggedAsync(taggedScene, captureUrl)
+            .then(function () { return taggedScene; })
+            .catch(function (error) {
+                console.warn("[glTF Physics Export] Tagged load failed, falling back to plain loader:", error);
+                taggedScene.dispose();
+                return BABYLON.SceneLoader.LoadAsync(
+                    sceneSource.rootUrl, sceneSource.sceneFilename, engine, undefined, pluginExtension);
+            });
+    } else {
+        loadPromise = BABYLON.SceneLoader.LoadAsync(
+            sceneSource.rootUrl, sceneSource.sceneFilename, engine, undefined, pluginExtension);
+    }
+
+    return loadPromise.then(async function (newScene) {
 
         scene = newScene;
 
         if (BABYLON.GLTFPhysicsExport) {
-            const captureUrl = getCaptureUrl(sceneSource);
-            if (pluginExtension === ".glb") {
+            // Capture for a self-contained .glb always, and for any remote
+            // model (so .gltf + .bin test models round-trip too).
+            if (pluginExtension === ".glb" || isRemoteSource) {
                 try {
                     await BABYLON.GLTFPhysicsExport.captureLoadedAsync(scene, captureUrl);
                 } catch (error) {

--- a/examples/babylonjs_webgpu/index.js
+++ b/examples/babylonjs_webgpu/index.js
@@ -366,18 +366,44 @@ let createScene = function(engine, modelSource) {
         });
     });
 
-    return BABYLON.SceneLoader.LoadAsync(
-        sceneSource.rootUrl,
-        sceneSource.sceneFilename,
-        engine,
-        undefined,
-        pluginExtension
-    ).then(async function (newScene) {
+    const captureUrl = getCaptureUrl(sceneSource);
+    // Drag-dropped / data-URI models resolve their external buffers and
+    // textures through an in-memory file map that appendTaggedAsync can't
+    // see, so only http(s) sources take the tagged path.
+    const isRemoteSource = !(sceneSource.sceneFilename.startsWith("blob:")
+        || sceneSource.sceneFilename.startsWith("data:"));
+
+    let loadPromise;
+    if (isRemoteSource
+        && BABYLON.GLTFPhysicsExport
+        && typeof BABYLON.GLTFPhysicsExport.appendTaggedAsync === "function") {
+        // Stamp every source node with its index and splice in any missing
+        // top-level physics extension blocks before the loader runs, so
+        // KHR_physics_rigid_bodies round-trips through the exporter even for
+        // nameless / duplicate-named nodes (e.g. the RigidBodies_* tests,
+        // whose nodes are unnamed and whose top-level rigid-bodies block is
+        // omitted). Non-physics models pass through untouched.
+        const taggedScene = new BABYLON.Scene(engine);
+        loadPromise = BABYLON.GLTFPhysicsExport.appendTaggedAsync(taggedScene, captureUrl)
+            .then(function () { return taggedScene; })
+            .catch(function (error) {
+                console.warn("[glTF Physics Export] Tagged load failed, falling back to plain loader:", error);
+                taggedScene.dispose();
+                return BABYLON.SceneLoader.LoadAsync(
+                    sceneSource.rootUrl, sceneSource.sceneFilename, engine, undefined, pluginExtension);
+            });
+    } else {
+        loadPromise = BABYLON.SceneLoader.LoadAsync(
+            sceneSource.rootUrl, sceneSource.sceneFilename, engine, undefined, pluginExtension);
+    }
+
+    return loadPromise.then(async function (newScene) {
         scene = newScene;
 
         if (BABYLON.GLTFPhysicsExport) {
-            const captureUrl = getCaptureUrl(sceneSource);
-            if (pluginExtension === ".glb") {
+            // Capture for a self-contained .glb always, and for any remote
+            // model (so .gltf + .bin test models round-trip too).
+            if (pluginExtension === ".glb" || isRemoteSource) {
                 try {
                     await BABYLON.GLTFPhysicsExport.captureLoadedAsync(scene, captureUrl);
                 } catch (error) {


### PR DESCRIPTION
## Summary

Remote `http(s)` models in the Babylon.js samples now load through `GLTFPhysicsExport.appendTaggedAsync`, which stamps every source node with its index and splices in any missing top-level physics extension blocks **before** the loader runs. This lets `KHR_physics_rigid_bodies` round-trip through the exporter even for the `RigidBodies_*` tests, whose nodes are unnamed and whose top-level rigid-bodies block is omitted.

- Drag-dropped / `data:` URI models keep the plain loader — their external buffers/textures live in an in-memory file map the tagged loader cannot see.
- Any tagged-load failure logs a warning and falls back to the plain loader.
- Capture now runs for **any remote source**, not only self-contained `.glb`, so `.gltf` + `.bin` test models round-trip too.

Applied to both the WebGL (`examples/babylonjs/index.js`) and WebGPU (`examples/babylonjs_webgpu/index.js`) Babylon.js samples.

## Test plan

- [ ] Load a remote `RigidBodies_*` test model (unnamed nodes, no top-level rigid-bodies block) and confirm `KHR_physics_rigid_bodies` is exported on re-capture.
- [ ] Load a remote `.gltf` + `.bin` model and confirm physics extensions round-trip.
- [ ] Drag-drop / `data:` URI models still load via the plain loader without errors.
- [ ] Force a tagged-load failure and confirm the plain-loader fallback engages.
- [ ] Verify behaviour in both the WebGL and WebGPU samples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)