### PR TITLE
fix(babylonjs): show Physics Debug wireframes for drag-dropped glTF physics models

### DIFF
--- a/examples/babylonjs/index.js
+++ b/examples/babylonjs/index.js
@@ -677,24 +677,48 @@ let createScene = function(engine, modelSource) {
         });
 
         let physicsViewer = null;
+        const shownPhysicsBodies = new Set();
         function showPhysicsDebug(value) {
             if (value) {
                 if (!physicsViewer && BABYLON.PhysicsViewer) {
                     physicsViewer = new BABYLON.PhysicsViewer(scene);
                 }
                 if (physicsViewer) {
-                    scene.meshes.forEach(function(m) {
-                        if (m.physicsBody) {
-                            try { physicsViewer.showBody(m.physicsBody); } catch(e) {}
+                    // Rigid bodies attach to whichever glTF node carries the
+                    // extension, which is often a TransformNode (not present in
+                    // scene.meshes), so walk both lists and skip bodies that are
+                    // already being shown.
+                    scene.meshes.concat(scene.transformNodes).forEach(function(node) {
+                        const body = node.physicsBody;
+                        if (body && !shownPhysicsBodies.has(body)) {
+                            try {
+                                physicsViewer.showBody(body);
+                                shownPhysicsBodies.add(body);
+                            } catch(e) {}
                         }
                     });
                 }
             } else if (physicsViewer) {
                 physicsViewer.dispose();
                 physicsViewer = null;
+                shownPhysicsBodies.clear();
             }
         }
-        if (params.PHYSICS_DEBUG) showPhysicsDebug(true);
+        // Always show the physics wireframes for glTF physics models. Some
+        // bodies (e.g. on drag-dropped models) only finish initializing after
+        // the first frame, so re-apply once the scene has rendered.
+        if (physicsExtensionLoaded && !params.PHYSICS_DEBUG) {
+            params.PHYSICS_DEBUG = true;
+            guiPhysicsDebug.updateDisplay();
+        }
+        if (params.PHYSICS_DEBUG) {
+            showPhysicsDebug(true);
+            if (physicsExtensionLoaded) {
+                scene.onAfterRenderObservable.addOnce(function() {
+                    if (params.PHYSICS_DEBUG) showPhysicsDebug(true);
+                });
+            }
+        }
         guiPhysicsDebug.onChange(showPhysicsDebug);
 
         scene._viewerGui = gui;

--- a/examples/babylonjs_webgpu/index.js
+++ b/examples/babylonjs_webgpu/index.js
@@ -572,24 +572,48 @@ let createScene = function(engine, modelSource) {
         });
 
         let physicsViewer = null;
+        const shownPhysicsBodies = new Set();
         function showPhysicsDebug(value) {
             if (value) {
                 if (!physicsViewer && BABYLON.PhysicsViewer) {
                     physicsViewer = new BABYLON.PhysicsViewer(scene);
                 }
                 if (physicsViewer) {
-                    scene.meshes.forEach(function(m) {
-                        if (m.physicsBody) {
-                            try { physicsViewer.showBody(m.physicsBody); } catch(e) {}
+                    // Rigid bodies attach to whichever glTF node carries the
+                    // extension, which is often a TransformNode (not present in
+                    // scene.meshes), so walk both lists and skip bodies that are
+                    // already being shown.
+                    scene.meshes.concat(scene.transformNodes).forEach(function(node) {
+                        const body = node.physicsBody;
+                        if (body && !shownPhysicsBodies.has(body)) {
+                            try {
+                                physicsViewer.showBody(body);
+                                shownPhysicsBodies.add(body);
+                            } catch(e) {}
                         }
                     });
                 }
             } else if (physicsViewer) {
                 physicsViewer.dispose();
                 physicsViewer = null;
+                shownPhysicsBodies.clear();
             }
         }
-        if (params.PHYSICS_DEBUG) showPhysicsDebug(true);
+        // Always show the physics wireframes for glTF physics models. Some
+        // bodies (e.g. on drag-dropped models) only finish initializing after
+        // the first frame, so re-apply once the scene has rendered.
+        if (physicsExtensionLoaded && !params.PHYSICS_DEBUG) {
+            params.PHYSICS_DEBUG = true;
+            guiPhysicsDebug.updateDisplay();
+        }
+        if (params.PHYSICS_DEBUG) {
+            showPhysicsDebug(true);
+            if (physicsExtensionLoaded) {
+                scene.onAfterRenderObservable.addOnce(function() {
+                    if (params.PHYSICS_DEBUG) showPhysicsDebug(true);
+                });
+            }
+        }
         guiPhysicsDebug.onChange(showPhysicsDebug);
 
         scene._viewerGui = gui;


### PR DESCRIPTION
## Problem

"Physics Debug" is enabled by default in the GUI, but when a glTF physics-extension model is loaded via **drag & drop**, no wireframes appear — the feature effectively behaves as if it were off.

## Cause

`showPhysicsDebug` only iterated `scene.meshes`. However, `KHR_physics_rigid_bodies` / `MSFT_rigid_bodies` bodies are attached by the loader to whichever glTF node carries the extension, which is frequently a `TransformNode` (in `scene.transformNodes`, **not** `scene.meshes`). Those bodies were therefore never passed to `PhysicsViewer`, so no wireframe was drawn.

## Fix

- Walk both `scene.meshes` and `scene.transformNodes`, tracking already-shown bodies in a `Set` to avoid duplicate debug meshes.
- Force Physics Debug on when a physics extension is detected, syncing the dat.GUI checkbox via `updateDisplay()`.
- Re-apply once after the first render (`onAfterRenderObservable`), since bodies on drag-dropped models can finish initializing a frame late.

Applied to both the WebGL (`examples/babylonjs`) and WebGPU (`examples/babylonjs_webgpu`) samples.

## Testing

Verified manually: dropping a glTF physics-extension model now displays the physics shapes as wireframes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)