### PR TITLE
fix(babylonjs-lite): add Draco decoder for KHR_draco_mesh_compression

### DIFF
--- a/examples/babylonjs-lite/index.html
+++ b/examples/babylonjs-lite/index.html
@@ -26,6 +26,24 @@
 <!-- dat.gui.js -->
 <script src="../../libs/common/dat.gui.js"></script>
 
+<!-- Draco decoder for KHR_draco_mesh_compression support.
+     Lite checks globalThis.DracoDecoderModule first; if present, uses it directly
+     instead of fetching from the (nonexistent) site root. The wrapper overrides
+     locateFile so the WASM is resolved from the same libs directory. -->
+<script src="../../libs/babylonjs/9.4.1/draco_decoder.js"></script>
+<script>
+(function() {
+    var orig = window.DracoDecoderModule;
+    if (typeof orig !== 'function') return;
+    var base = new URL("../../libs/babylonjs/9.4.1/", document.baseURI).href;
+    window.DracoDecoderModule = function(cfg) {
+        return orig(Object.assign({}, cfg, {
+            locateFile: function(f) { return base + f; }
+        }));
+    };
+})();
+</script>
+
 <canvas id="renderCanvas"></canvas>
 <div id="dropZone" class="drop-zone hidden">
   <div class="drop-zone__panel">


### PR DESCRIPTION
## Summary

- Babylon Lite's Draco loader falls back to fetching `draco_decoder.js` from the **site root** (`/draco_decoder.js`) when `globalThis.DracoDecoderModule` is not pre-loaded. On this host that path returns 404.
- Fix: pre-load the decoder from `libs/babylonjs/9.4.1/draco_decoder.js` (already in the project) via a synchronous `<script>` tag — which runs before the ES module script — then wrap the factory to override `locateFile` so the companion `draco_decoder.wasm` is also fetched from that directory.

**How it works:**
1. `<script src="draco_decoder.js">` loads and assigns the Emscripten factory to `window.DracoDecoderModule`
2. The inline wrapper replaces it with a function that forwards the call but forces `locateFile(f)` → `abs_path/libs/babylonjs/9.4.1/{f}`
3. When Lite encounters `KHR_draco_mesh_compression`, it finds `DracoDecoderModule` pre-loaded and calls the wrapper; WASM is fetched from the correct local path

## Test plan

- [ ] Open `examples/babylonjs-lite/?model=Duck` (glTF-Draco) — Duck renders without Draco 404 error
- [ ] Open `examples/babylonjs-lite/?model=Duck` (plain glTF) — no regression, decoder is loaded but unused
- [ ] Console shows no `ERR_ABORTED 404` for `draco_decoder.js` or `draco_decoder.wasm`

🤖 Generated with [Claude Code](https://claude.com/claude-code)