### PR TITLE
fix(babylonjs-lite): remove default ground plane from loadEnvironment

### DIFF
--- a/examples/babylonjs-lite/index.js
+++ b/examples/babylonjs-lite/index.js
@@ -341,6 +341,7 @@ async function createScene(engine, modelSource) {
             brdfUrl: BRDF_URL,
             skyboxUrl: ENV_URL,
             skyboxSize: 10000,
+            skipGround: true,
         }),
         // Fetch camera nodes in parallel with model loading; returns [] for GLB/blob URLs.
         extractGltfCameras(absolutePath),


### PR DESCRIPTION
## Summary

`loadEnvironment` creates a reflective ground plane by default when `skipGround` is not set. This appeared as a large purple/metallic floor overlaid on every loaded model (visible in the attached screenshot). The Babylon.js reference viewer has no ground plane. Fix: add `skipGround: true` to the `loadEnvironment` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)