### PR TITLE
feat(babylonjs-lite): add Lights toggle and fix CubeMap toggle

### DIFF
--- a/examples/babylonjs-lite/index.js
+++ b/examples/babylonjs-lite/index.js
@@ -55,7 +55,6 @@ let params = {
     CUBEMAP: true,
     IBL: true,
     LIGHTS: false,
-    TONEMAP: 'Standard',
     VARIANT: DEFAULT_NAME,
     CAMERA: DEFAULT_NAME,
 };
@@ -229,26 +228,6 @@ async function createDroppedModelSource(fileList) {
         displayName: modelFile.name,
         objectUrls: objectUrls,
     };
-}
-
-// ── Tonemap helper ───────────────────────────────────────────────────────────
-
-function applyTonemap(scene, value) {
-    if (value === 'None') {
-        scene.imageProcessing.toneMappingEnabled = false;
-    } else {
-        scene.imageProcessing.toneMappingEnabled = true;
-        scene.imageProcessing.toneMappingType = value.toLowerCase();
-    }
-    // writePassSceneUBO caches against exposure/contrast/camera but not
-    // toneMappingEnabled, so the scene UBO silently skips the update when
-    // only toneMappingEnabled changes. Clearing _su forces a cache miss on the
-    // next frame so the new value reaches the PBR shader immediately.
-    if (scene._frameGraph) {
-        scene._frameGraph._tasks.forEach(function(t) {
-            if (t._su) t._su.length = 0;
-        });
-    }
 }
 
 // ── glTF camera helpers ──────────────────────────────────────────────────────
@@ -453,13 +432,6 @@ function setupSceneGui(scene) {
         light1.intensity = value ? 1.0 : 0;
         light2.intensity = value ? 1.0 : 0;
     });
-
-    const tonemaps = ['None', 'Standard', 'ACES'];
-    params.TONEMAP = 'Standard';
-    gui.add(params, 'TONEMAP', tonemaps).name('Tonemap').onChange(function(value) {
-        applyTonemap(scene, value);
-    });
-    applyTonemap(scene, params.TONEMAP);
 
     if (variantNames.length > 0) {
         const variantOptions = {};

--- a/examples/babylonjs-lite/index.js
+++ b/examples/babylonjs-lite/index.js
@@ -15,6 +15,7 @@ import {
     getVariantNames,
     selectVariant,
     resetVariant,
+    createDirectionalLight,
 } from "babylon-lite";
 
 const ENV_URL = "../../textures/env/papermillSpecularHDR.env";
@@ -53,6 +54,8 @@ let params = {
     ROTATE: false,
     CUBEMAP: true,
     IBL: true,
+    LIGHTS: false,
+    TONEMAP: 'Standard',
     VARIANT: DEFAULT_NAME,
     CAMERA: DEFAULT_NAME,
 };
@@ -228,6 +231,17 @@ async function createDroppedModelSource(fileList) {
     };
 }
 
+// ── Tonemap helper ───────────────────────────────────────────────────────────
+
+function applyTonemap(scene, value) {
+    if (value === 'None') {
+        scene.imageProcessing.toneMappingEnabled = false;
+    } else {
+        scene.imageProcessing.toneMappingEnabled = true;
+        scene.imageProcessing.toneMappingType = value.toLowerCase();
+    }
+}
+
 // ── glTF camera helpers ──────────────────────────────────────────────────────
 
 function _qMul(a, b) {
@@ -349,6 +363,11 @@ async function createScene(engine, modelSource) {
 
     addToScene(scene, loadedAsset);
 
+    const light1 = createDirectionalLight([0.0, -1.0, 0.5], 0);
+    const light2 = createDirectionalLight([-0.5, -0.5, -0.5], 0);
+    addToScene(scene, light1);
+    addToScene(scene, light2);
+
     const cam = createDefaultCamera(scene);
     // Lite default is alpha=-π/2 (camera at -Z); match babylonjs_webgpu which
     // uses setPosition(0,3,5), equivalent to alpha=+π/2 (camera at +Z, front view).
@@ -381,13 +400,15 @@ async function createScene(engine, modelSource) {
         variantNames: getVariantNames(loadedAsset),
         gltfCameras,
         defaultCamParams,
+        light1,
+        light2,
     };
 
     return scene;
 }
 
 function setupSceneGui(scene) {
-    const { asset, envTextures, variantNames, cam, gltfCameras, defaultCamParams } = scene._sceneData;
+    const { asset, envTextures, variantNames, cam, gltfCameras, defaultCamParams, light1, light2 } = scene._sceneData;
 
     const gui = new dat.GUI();
     gui.add(params, 'ROTATE').name('Rotate');
@@ -413,8 +434,20 @@ function setupSceneGui(scene) {
     gui.add(params, 'IBL').name('IBL').onChange(function(value) {
         scene._envTextures = value ? envTextures : null;
         scene.imageProcessing.exposure = value ? 0.8 : 1.0;
-        scene.imageProcessing.toneMappingEnabled = value;
     });
+
+    params.LIGHTS = false;
+    gui.add(params, 'LIGHTS').name('Lights').onChange(function(value) {
+        light1.intensity = value ? 1.0 : 0;
+        light2.intensity = value ? 1.0 : 0;
+    });
+
+    const tonemaps = ['None', 'Standard', 'ACES'];
+    params.TONEMAP = 'Standard';
+    gui.add(params, 'TONEMAP', tonemaps).name('Tonemap').onChange(function(value) {
+        applyTonemap(scene, value);
+    });
+    applyTonemap(scene, params.TONEMAP);
 
     if (variantNames.length > 0) {
         const variantOptions = {};

--- a/examples/babylonjs-lite/index.js
+++ b/examples/babylonjs-lite/index.js
@@ -240,6 +240,15 @@ function applyTonemap(scene, value) {
         scene.imageProcessing.toneMappingEnabled = true;
         scene.imageProcessing.toneMappingType = value.toLowerCase();
     }
+    // writePassSceneUBO caches against exposure/contrast/camera but not
+    // toneMappingEnabled, so the scene UBO silently skips the update when
+    // only toneMappingEnabled changes. Clearing _su forces a cache miss on the
+    // next frame so the new value reaches the PBR shader immediately.
+    if (scene._frameGraph) {
+        scene._frameGraph._tasks.forEach(function(t) {
+            if (t._su) t._su.length = 0;
+        });
+    }
 }
 
 // ── glTF camera helpers ──────────────────────────────────────────────────────
@@ -428,6 +437,9 @@ function setupSceneGui(scene) {
         } else if (!value && idx >= 0) {
             scene._renderables.splice(idx, 1);
         }
+        // Increment _renderableVersion so the render task detects the change and
+        // re-records its GPU render bundle on the next frame.
+        scene._renderableVersion++;
     });
 
     params.IBL = true;


### PR DESCRIPTION
## Summary

Extend the Babylon.js Lite control box toward parity with the full Babylon.js viewer, within the limits of Lite's public API.

### Added
- **Lights** — toggle two `DirectionalLight`s matching the direction vectors used in the full viewer (`[0, -1, 0.5]` and `[-0.5, -0.5, -0.5]`). Off by default; intensity 0 ↔ 1.0.

### Fixed
- **CubeMap** toggle — modifying `scene._renderables` alone does not trigger a re-record of the GPU render bundle. Incrementing `_renderableVersion` signals the render task to re-record on the next frame.

### Investigated but not added
- **Tonemap** — Lite bakes tone mapping into each PBR material's shader at compile time (the scene feature bitmask is captured in the renderable's rebuild closure, and `loadEnvironment` enables it before materials build). There is no public API to recompile materials, and toggling `scene.imageProcessing.toneMappingEnabled` at runtime has no effect. The skybox is never tone-mapped either. A non-functional control was therefore not shipped.
- **Bounding Box / Bloom / Debug / Physics Debug / Export glTF Physics** — no Lite API equivalent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)