### PR TITLE
chore(babylonjs-lite): bump @babylonjs/lite to 1.2.0

### DIFF
--- a/examples/babylonjs-lite/index.html
+++ b/examples/babylonjs-lite/index.html
@@ -7,7 +7,7 @@
 <script type="importmap">
 {
   "imports": {
-    "babylon-lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.0.1/index.js"
+    "babylon-lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js"
   }
 }
 </script>


### PR DESCRIPTION
## Summary
- Update the Babylon.js Lite example to use `@babylonjs/lite@1.2.0` (was `1.0.1`).

## Changes
- `examples/babylonjs-lite/index.html`: import map updated to `https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.2.0/index.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)