### PR TITLE
fix(babylonjs-lite): make jointed physics assemblies (WaterWheel, Robot_skinned) work

### DIFF
--- a/examples/babylonjs-lite/index.js
+++ b/examples/babylonjs-lite/index.js
@@ -275,33 +275,126 @@ function _rotateByQ(q, v) {
     };
 }
 
-// Fetch a glTF asset URL and return its parsed JSON, handling .gltf, .glb (binary,
-// from which the JSON chunk is extracted), and blob: URLs (drag-dropped models are
-// normalised to a .gltf JSON blob upstream). Returns null on fetch/parse failure.
-async function fetchGltfJsonAny(url) {
+// Fetch a glTF asset URL and return { json, glbBin } where glbBin is the GLB binary
+// chunk (ArrayBuffer) or null. Handles .gltf, .glb (binary), and blob: URLs
+// (drag-dropped models are normalised to a .gltf JSON blob upstream). Returns
+// { json: null, glbBin: null } on fetch/parse failure.
+async function fetchGltfAsset(url) {
     try {
         const resp = await fetch(url);
-        if (!resp.ok) return null;
+        if (!resp.ok) return { json: null, glbBin: null };
         const buffer = await resp.arrayBuffer();
         const dv = new DataView(buffer);
-        // GLB magic "glTF" → walk the binary chunks for the JSON chunk.
+        // GLB magic "glTF" → walk the binary chunks for the JSON and BIN chunks.
         if (buffer.byteLength >= 12 && dv.getUint32(0, true) === 0x46546C67) {
+            let json = null;
+            let glbBin = null;
             let offset = 12;
             while (offset + 8 <= dv.byteLength) {
                 const chunkLength = dv.getUint32(offset, true);
                 const chunkType = dv.getUint32(offset + 4, true);
                 const dataStart = offset + 8;
                 if (chunkType === 0x4E4F534A) { // "JSON"
-                    return JSON.parse(new TextDecoder().decode(new Uint8Array(buffer, dataStart, chunkLength)));
+                    json = JSON.parse(new TextDecoder().decode(new Uint8Array(buffer, dataStart, chunkLength)));
+                } else if (chunkType === 0x004E4942) { // "BIN\0"
+                    glbBin = buffer.slice(dataStart, dataStart + chunkLength);
                 }
                 offset = dataStart + chunkLength;
             }
-            return null;
+            return { json, glbBin };
         }
-        return JSON.parse(new TextDecoder().decode(new Uint8Array(buffer)));
+        return { json: JSON.parse(new TextDecoder().decode(new Uint8Array(buffer))), glbBin: null };
     } catch (e) {
-        return null;
+        return { json: null, glbBin: null };
     }
+}
+
+// Resolve every glTF buffer to an ArrayBuffer: the embedded GLB binary chunk for the
+// uri-less buffer, data: URIs decoded inline, and external URIs fetched relative to
+// the model. Used to decode collision-only mesh geometry the visual loader skips.
+async function resolveGltfBuffers(json, baseUrl, glbBin) {
+    const buffers = [];
+    for (const buffer of (json.buffers || [])) {
+        if (!buffer.uri) {
+            buffers.push(glbBin);
+        } else if (buffer.uri.startsWith("data:")) {
+            const base64 = buffer.uri.slice(buffer.uri.indexOf(",") + 1);
+            const binary = atob(base64);
+            const bytes = new Uint8Array(binary.length);
+            for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+            buffers.push(bytes.buffer);
+        } else {
+            const resp = await fetch(new URL(buffer.uri, baseUrl).href);
+            buffers.push(await resp.arrayBuffer());
+        }
+    }
+    return buffers;
+}
+
+// Read a VEC3 FLOAT accessor (e.g. POSITION) as a flat Float32Array, honouring bufferView stride.
+function readAccessorVec3(json, buffers, accessorIndex) {
+    const acc = json.accessors[accessorIndex];
+    const bv = json.bufferViews[acc.bufferView];
+    const dv = new DataView(buffers[bv.buffer]);
+    const base = (bv.byteOffset || 0) + (acc.byteOffset || 0);
+    const stride = bv.byteStride || 12;
+    const out = new Float32Array(acc.count * 3);
+    for (let i = 0; i < acc.count; i++) {
+        const o = base + i * stride;
+        out[i * 3] = dv.getFloat32(o, true);
+        out[i * 3 + 1] = dv.getFloat32(o + 4, true);
+        out[i * 3 + 2] = dv.getFloat32(o + 8, true);
+    }
+    return out;
+}
+
+// Read a SCALAR index accessor (ubyte/ushort/uint) as a Uint32Array.
+function readAccessorIndices(json, buffers, accessorIndex) {
+    const acc = json.accessors[accessorIndex];
+    const bv = json.bufferViews[acc.bufferView];
+    const dv = new DataView(buffers[bv.buffer]);
+    const base = (bv.byteOffset || 0) + (acc.byteOffset || 0);
+    const size = acc.componentType === 5125 ? 4 : acc.componentType === 5123 ? 2 : 1;
+    const stride = bv.byteStride || size;
+    const out = new Uint32Array(acc.count);
+    for (let i = 0; i < acc.count; i++) {
+        const o = base + i * stride;
+        out[i] = acc.componentType === 5125 ? dv.getUint32(o, true)
+            : acc.componentType === 5123 ? dv.getUint16(o, true)
+            : dv.getUint8(o);
+    }
+    return out;
+}
+
+// Build a minimal mesh-like object (positions + indices + a pure-scale world matrix) from a glTF
+// mesh's accessors, for collider meshes the visual loader never instantiates (collision-only or a
+// mesh index differing from the node's own). It exposes exactly what Lite's MeshAccumulator reads.
+function buildColliderMeshFromGltf(json, buffers, meshIndex, scale) {
+    const positions = [];
+    const indices = [];
+    let vertexOffset = 0;
+    for (const prim of (json.meshes[meshIndex].primitives || [])) {
+        if (prim.attributes?.POSITION === undefined) continue;
+        const pos = readAccessorVec3(json, buffers, prim.attributes.POSITION);
+        for (let i = 0; i < pos.length; i++) positions.push(pos[i]);
+        if (prim.indices !== undefined) {
+            const idx = readAccessorIndices(json, buffers, prim.indices);
+            for (let i = 0; i < idx.length; i++) indices.push(idx[i] + vertexOffset);
+        } else {
+            const count = pos.length / 3;
+            for (let i = 0; i < count; i++) indices.push(i + vertexOffset);
+        }
+        vertexOffset += pos.length / 3;
+    }
+    const [sx, sy, sz] = scale;
+    return {
+        _gpu: {},
+        _cpuPositions: Float32Array.from(positions),
+        _cpuIndices: Uint32Array.from(indices),
+        scaling: { x: sx, y: sy, z: sz },
+        worldMatrix: [sx, 0, 0, 0, 0, sy, 0, 0, 0, 0, sz, 0, 0, 0, 0, 1],
+        children: [],
+    };
 }
 
 // Parse the cameras from a glTF JSON object and return their world positions
@@ -611,12 +704,27 @@ function buildGltfJoints(world, json, parentMap, jointDefs, bodyByNode) {
 // Build Havok rigid bodies from a model's glTF physics extensions and reparent the
 // matching visual subtrees under physics anchors so they follow the simulation.
 // Returns { world, viewer, bodies } or null when the asset has no physics.
-async function setupGltfPhysics(scene, json, loadedAsset) {
+async function setupGltfPhysics(scene, json, loadedAsset, glbBin, baseUrl) {
     const shapeDefs = json.extensions?.KHR_implicit_shapes?.shapes || [];
     const scenePhysics = json.extensions?.KHR_physics_rigid_bodies || {};
     const materialDefs = scenePhysics.physicsMaterials || [];
     const jointDefs = scenePhysics.physicsJoints || [];
     const parentMap = buildParentMap(json);
+
+    // Collider meshes the visual loader never instantiates (collision-only, or a mesh index
+    // differing from the node's own) must be decoded straight from the glTF buffers.
+    const needsBuffers = json.nodes.some(function(n) {
+        const g = n.extensions?.KHR_physics_rigid_bodies?.collider?.geometry;
+        return g && g.shape === undefined && g.mesh !== undefined && n.mesh !== g.mesh;
+    });
+    let buffers = null;
+    if (needsBuffers) {
+        try {
+            buffers = await resolveGltfBuffers(json, baseUrl, glbBin);
+        } catch (error) {
+            console.warn("[glTF Physics] Failed to resolve buffers for collision-only meshes:", error);
+        }
+    }
 
     const hknp = await loadHavok();
     const world = createHavokWorld(scene, hknp, { x: 0, y: -9.8, z: 0 });
@@ -676,11 +784,17 @@ async function setupGltfPhysics(scene, json, loadedAsset) {
         return { anchor, lh };
     };
 
-    const buildShapeFor = (geometry, anchorForMesh, absScale) => {
+    const buildShapeFor = (nodeIndex, geometry, anchorForMesh, absScale, meshScale) => {
         if (geometry.shape !== undefined) {
             return createPhysicsShape(world, primitiveShapeOptions(shapeDefs[geometry.shape], absScale));
         }
         const type = geometry.convexHull ? PhysicsShapeType.CONVEX_HULL : PhysicsShapeType.MESH;
+        // Collision-only / mismatched collider mesh: decode geometry.mesh straight from the buffers.
+        // Otherwise the node renders exactly the collider mesh, so accumulate its loaded subtree.
+        if (geometry.mesh !== undefined && json.nodes[nodeIndex]?.mesh !== geometry.mesh && buffers) {
+            const meshLike = buildColliderMeshFromGltf(json, buffers, geometry.mesh, meshScale || absScale);
+            return createPhysicsShape(world, { type, mesh: meshLike, includeChildMeshes: false });
+        }
         return createPhysicsShape(world, { type, mesh: anchorForMesh, includeChildMeshes: true });
     };
 
@@ -698,7 +812,7 @@ async function setupGltfPhysics(scene, json, loadedAsset) {
             for (const childIndex of compound.childColliders) {
                 const childGeom = json.nodes[childIndex].extensions.KHR_physics_rigid_bodies.collider.geometry;
                 // Primitive child: base size; the parent-relative transform carries the world scale.
-                const childShape = buildShapeFor(childGeom, nodeToTN.get(childIndex), [1, 1, 1]);
+                const childShape = buildShapeFor(childIndex, childGeom, nodeToTN.get(childIndex), [1, 1, 1], [1, 1, 1]);
                 setMaterial(childShape, json.nodes[childIndex].extensions.KHR_physics_rigid_bodies.collider.physicsMaterial);
                 addPhysicsShapeChildFromParent(world, container, anchor, childShape, nodeToTN.get(childIndex));
             }
@@ -715,7 +829,7 @@ async function setupGltfPhysics(scene, json, loadedAsset) {
 
         const { anchor, lh } = placeAnchor(nodeIndex);
         const absScale = lh.scale.map(Math.abs);
-        const shape = buildShapeFor(geometry, anchor, absScale);
+        const shape = buildShapeFor(nodeIndex, geometry, anchor, absScale, lh.scale);
         setMaterial(shape, physics.collider.physicsMaterial);
         // A kinematic body is ANIMATED: Lite snaps it to its node each pre-step, so it is driven
         // by rotating its anchor (see spinners below) rather than by a set velocity.
@@ -778,7 +892,7 @@ async function createScene(engine, modelSource) {
 
     const absolutePath = new URL(path, window.location.href).href;
 
-    const [loadedAsset, envTextures, gltfJson] = await Promise.all([
+    const [loadedAsset, envTextures, gltfAsset] = await Promise.all([
         loadGltf(engine, absolutePath),
         loadEnvironment(scene, ENV_URL, {
             brdfUrl: BRDF_URL,
@@ -786,10 +900,11 @@ async function createScene(engine, modelSource) {
             skyboxSize: 10000,
             skipGround: true,
         }),
-        // Fetch the glTF JSON in parallel with model loading (used for cameras and physics).
-        fetchGltfJsonAny(absolutePath),
+        // Fetch the glTF JSON (+ GLB binary) in parallel with model loading, for cameras and physics.
+        fetchGltfAsset(absolutePath),
     ]);
 
+    const gltfJson = gltfAsset.json;
     const gltfCameras = gltfJson ? parseGltfCameras(gltfJson) : [];
 
     addToScene(scene, loadedAsset);
@@ -801,7 +916,7 @@ async function createScene(engine, modelSource) {
     if (hasGltfPhysics(gltfJson)) {
         scene.fixedDeltaMs = 1000 / PHYSICS_FPS;
         try {
-            physicsData = await setupGltfPhysics(scene, gltfJson, loadedAsset);
+            physicsData = await setupGltfPhysics(scene, gltfJson, loadedAsset, gltfAsset.glbBin, absolutePath);
         } catch (error) {
             console.error("[glTF Physics] Failed to set up physics:", error);
         }

--- a/examples/babylonjs-lite/index.js
+++ b/examples/babylonjs-lite/index.js
@@ -621,10 +621,13 @@ function primitiveShapeOptions(shapeDef, absScale) {
 
 // Apply a KHR_physics_rigid_bodies "motion" block to a dynamic body: mass, centre of
 // mass, inertia, gravity factor (negative = floating balloons), and initial velocities.
-function applyMotionProperties(world, hknp, body, motion) {
+// defaultInertia supplies a fallback inertia for shapeless bodies (empty collider) whose
+// inertia Havok cannot derive from a shape.
+function applyMotionProperties(world, hknp, body, motion, defaultInertia) {
     const massProps = { mass: motion.mass ?? 1 };
     if (Array.isArray(motion.centerOfMass)) massProps.centerOfMass = { x: motion.centerOfMass[0], y: motion.centerOfMass[1], z: motion.centerOfMass[2] };
     if (Array.isArray(motion.inertiaDiagonal)) massProps.inertia = { x: motion.inertiaDiagonal[0], y: motion.inertiaDiagonal[1], z: motion.inertiaDiagonal[2] };
+    else if (defaultInertia) massProps.inertia = { x: 1, y: 1, z: 1 };
     if (Array.isArray(motion.inertiaOrientation)) massProps.inertiaOrientation = { x: motion.inertiaOrientation[0], y: motion.inertiaOrientation[1], z: motion.inertiaOrientation[2], w: motion.inertiaOrientation[3] };
     setPhysicsBodyMassProperties(world, body, massProps);
 
@@ -642,17 +645,55 @@ function hasGltfPhysics(json) {
     return json.nodes.some(function(n) { return n.extensions && n.extensions.KHR_physics_rigid_bodies; });
 }
 
+// A node owns a rigid body when it declares motion and/or a collider (compound parents and shapeless
+// "driver" bodies carry motion but no collider; static colliders carry no motion).
+function isPhysicsBodyRoot(json, nodeIndex) {
+    const p = json.nodes[nodeIndex].extensions?.KHR_physics_rigid_bodies;
+    return !!(p && (p.motion || p.collider));
+}
+
+// Apply a glTF joint's drives (motors) to a constraint, best-effort. The Lite wrapper exposes only
+// limits, so the motor functions are called on the raw Havok constraint handle. A drive with a
+// non-zero stiffness is a position motor; otherwise a velocity motor. Failures are swallowed so a
+// missing/renamed enum never aborts the rest of the physics setup.
+function applyJointDrives(hknp, constraint, jointDef) {
+    const drives = jointDef.drives;
+    if (!drives || !drives.length) return;
+    const CA = hknp.ConstraintAxis;
+    const MT = hknp.ConstraintMotorType;
+    const joint = constraint._hkConstraint;
+    if (!CA || !MT || !joint) return;
+    const linAxes = [CA.LINEAR_X, CA.LINEAR_Y, CA.LINEAR_Z];
+    const angAxes = [CA.ANGULAR_X, CA.ANGULAR_Y, CA.ANGULAR_Z];
+    for (const d of drives) {
+        try {
+            const nativeAxis = (d.type === "angular" ? angAxes : linAxes)[d.axis ?? 0];
+            if (nativeAxis === undefined) continue;
+            const usePosition = (d.stiffness ?? 0) > 0;
+            hknp.HP_Constraint_SetAxisMotorType(joint, nativeAxis, usePosition ? MT.POSITION : MT.VELOCITY);
+            if (usePosition && d.positionTarget !== undefined) hknp.HP_Constraint_SetAxisMotorPositionTarget(joint, nativeAxis, d.positionTarget);
+            if (d.velocityTarget !== undefined) hknp.HP_Constraint_SetAxisMotorVelocityTarget(joint, nativeAxis, d.velocityTarget);
+            if (d.stiffness !== undefined && typeof hknp.HP_Constraint_SetAxisMotorStiffness === "function") hknp.HP_Constraint_SetAxisMotorStiffness(joint, nativeAxis, d.stiffness);
+            if (d.damping !== undefined && typeof hknp.HP_Constraint_SetAxisMotorDamping === "function") hknp.HP_Constraint_SetAxisMotorDamping(joint, nativeAxis, d.damping);
+            if (d.maxForce !== undefined && typeof hknp.HP_Constraint_SetAxisMotorMaxForce === "function") hknp.HP_Constraint_SetAxisMotorMaxForce(joint, nativeAxis, d.maxForce);
+        } catch (error) {
+            console.warn("[glTF Physics] Failed to apply joint drive:", error);
+        }
+    }
+}
+
 // Build the SIX_DOF constraints declared by KHR_physics_rigid_bodies joints. glTF joints are
 // generic 6-DoF definitions (per-axis min/max limits); each jointSpace node owns one joint and
 // references the connected node's frame. Adapted from the gltf_physics_JointTypes reference.
-function buildGltfJoints(world, json, parentMap, jointDefs, bodyByNode) {
+function buildGltfJoints(world, hknp, scene, json, parentMap, jointDefs, bodyByNode) {
     if (!jointDefs.length) return;
 
-    // Resolve a jointSpace node to its owning body plus the anchor frame in that body's local space.
+    // Resolve a jointSpace node to its owning body plus the anchor frame in that body's local space,
+    // or null when the node has no body-root ancestor (= a world-fixed connection, handled below).
     const resolveBodyFrame = (jointSpaceIndex) => {
         let m = nodeLocalMatrix(json.nodes[jointSpaceIndex]);
         for (let cur = parentMap[jointSpaceIndex]; cur !== undefined; cur = parentMap[cur]) {
-            if (json.nodes[cur].extensions?.KHR_physics_rigid_bodies?.collider) {
+            if (isPhysicsBodyRoot(json, cur)) {
                 const entry = bodyByNode.get(cur);
                 if (!entry) return null;
                 const d = decomposeMatrix(m);
@@ -669,13 +710,26 @@ function buildGltfJoints(world, json, parentMap, jointDefs, bodyByNode) {
         return null;
     };
 
+    // Create a static, shapeless world-anchor body at a node's left-handed world pose, for joints
+    // whose connected node has no rigid body (a fixed-to-world connection). The frame is identity.
+    const worldAnchorFrame = (jointSpaceIndex) => {
+        const lh = decomposeMatrix(applyLeftHandedFlip(nodeWorldMatrix(json, parentMap, jointSpaceIndex)));
+        const anchor = createTransformNode("worldAnchor_" + jointSpaceIndex);
+        anchor.position.set(lh.position[0], lh.position[1], lh.position[2]);
+        anchor.rotationQuaternion.set(lh.quaternion[0], lh.quaternion[1], lh.quaternion[2], lh.quaternion[3]);
+        addToScene(scene, anchor);
+        const body = createPhysicsBody(world, anchor, PhysicsMotionType.STATIC);
+        setPhysicsBodyShape(world, body, createPhysicsShape(world, { type: PhysicsShapeType.CONTAINER }));
+        return { body, pivot: { x: 0, y: 0, z: 0 }, axis: { x: 1, y: 0, z: 0 }, perp: { x: 0, y: 1, z: 0 } };
+    };
+
     // Convert a glTF joint's per-axis limits to Lite SIX_DOF limits (LINEAR_X/Y/Z = 0..2,
     // ANGULAR_X/Y/Z = 3..5). Listed axes are locked (min==max) or limited; unlisted axes stay free.
     const buildLimits = (jointDef) => {
         const out = [];
         for (const lim of (jointDef.limits || [])) {
-            for (const a of (lim.linearAxes || [])) out.push({ axis: a, minLimit: lim.min ?? 0, maxLimit: lim.max ?? 0 });
-            for (const a of (lim.angularAxes || [])) out.push({ axis: 3 + a, minLimit: lim.min ?? 0, maxLimit: lim.max ?? 0 });
+            for (const a of (lim.linearAxes || [])) out.push({ axis: a, minLimit: lim.min ?? 0, maxLimit: lim.max ?? 0, stiffness: lim.stiffness, damping: lim.damping });
+            for (const a of (lim.angularAxes || [])) out.push({ axis: 3 + a, minLimit: lim.min ?? 0, maxLimit: lim.max ?? 0, stiffness: lim.stiffness, damping: lim.damping });
         }
         return out;
     };
@@ -683,21 +737,26 @@ function buildGltfJoints(world, json, parentMap, jointDefs, bodyByNode) {
     for (let nodeIndex = 0; nodeIndex < json.nodes.length; nodeIndex++) {
         const joint = json.nodes[nodeIndex].extensions?.KHR_physics_rigid_bodies?.joint;
         if (!joint) continue;
-        const frameA = resolveBodyFrame(nodeIndex);
-        const frameB = resolveBodyFrame(joint.connectedNode);
-        if (!frameA || !frameB) continue;
-        createPhysicsConstraint(
-            world,
-            frameA.body,
-            frameB.body,
-            PhysicsConstraintType.SIX_DOF,
-            {
-                pivotA: frameA.pivot, axisA: frameA.axis, perpAxisA: frameA.perp,
-                pivotB: frameB.pivot, axisB: frameB.axis, perpAxisB: frameB.perp,
-                collision: !!joint.enableCollision,
-            },
-            buildLimits(jointDefs[joint.joint] || {}),
-        );
+        try {
+            const frameA = resolveBodyFrame(nodeIndex) || worldAnchorFrame(nodeIndex);
+            const frameB = resolveBodyFrame(joint.connectedNode) || worldAnchorFrame(joint.connectedNode);
+            const jointDef = jointDefs[joint.joint] || {};
+            const constraint = createPhysicsConstraint(
+                world,
+                frameA.body,
+                frameB.body,
+                PhysicsConstraintType.SIX_DOF,
+                {
+                    pivotA: frameA.pivot, axisA: frameA.axis, perpAxisA: frameA.perp,
+                    pivotB: frameB.pivot, axisB: frameB.axis, perpAxisB: frameB.perp,
+                    collision: !!joint.enableCollision,
+                },
+                buildLimits(jointDef),
+            );
+            applyJointDrives(hknp, constraint, jointDef);
+        } catch (error) {
+            console.warn("[glTF Physics] Failed to build joint at node " + nodeIndex + ":", error);
+        }
     }
 }
 
@@ -825,7 +884,23 @@ async function setupGltfPhysics(scene, json, loadedAsset, glbBin, baseUrl) {
         }
 
         const geometry = physics.collider?.geometry;
-        if (!geometry) continue; // standalone triggers are skipped
+        if (!geometry) {
+            // Shapeless body: a motion-only "driver"/anchor (no collider) used by joints. Give it an
+            // empty container shape so Havok has a valid body; supply a default inertia.
+            if (motion) {
+                const { anchor, lh } = placeAnchor(nodeIndex);
+                const isKinematic = !!motion.isKinematic;
+                const body = createPhysicsBody(world, anchor, isKinematic ? PhysicsMotionType.ANIMATED : PhysicsMotionType.DYNAMIC);
+                setPhysicsBodyShape(world, body, createPhysicsShape(world, { type: PhysicsShapeType.CONTAINER }));
+                if (!isKinematic) {
+                    applyMotionProperties(world, hknp, body, motion, true);
+                } else if (Array.isArray(motion.angularVelocity)) {
+                    spinners.push({ anchor, omega: [motion.angularVelocity[0], -motion.angularVelocity[1], -motion.angularVelocity[2]] });
+                }
+                bodyByNode.set(nodeIndex, { body, scale: lh.scale });
+            }
+            continue; // standalone triggers (no motion) are skipped
+        }
 
         const { anchor, lh } = placeAnchor(nodeIndex);
         const absScale = lh.scale.map(Math.abs);
@@ -849,7 +924,7 @@ async function setupGltfPhysics(scene, json, loadedAsset, glbBin, baseUrl) {
         bodyByNode.set(nodeIndex, { body, scale: lh.scale });
     }
 
-    buildGltfJoints(world, json, parentMap, jointDefs, bodyByNode);
+    buildGltfJoints(world, hknp, scene, json, parentMap, jointDefs, bodyByNode);
 
     // Drive kinematic spinners: rotate each anchor by its angular velocity every physics step
     // (world-frame increment); Lite's pre-step teleport carries the body, driving its joint.


### PR DESCRIPTION
## Summary

Makes the jointed glTF physics samples **WaterWheel.glb** and **Robot_skinned.glb** load and simulate correctly in the Babylon.js Lite viewer. Two independent problems:

### 1. Collision-only collider meshes (initial crash)

Some colliders give `geometry.mesh` an index that is **not** the node's own rendered mesh — often a collision-only mesh the visual loader never instantiates (WaterWheel's Archimedes screw; Robot's body / leg colliders). The previous code accumulated geometry from the node's reparented visual subtree, which is empty for those nodes, so `createPhysicsShape` threw `Cannot create physics mesh shape without vertex positions.`

Fix: when `geometry.mesh` differs from the node's own mesh, decode that mesh straight from the glTF buffers (GLB binary chunk, `data:` and external URIs) and feed positions/indices to `createPhysicsShape` via a minimal mesh-like object scaled by the node's world scale.

### 2. Parts flew apart (joints dropped)

After the crash was fixed, parts scattered because joints were silently skipped:

- **World-fixed joints** (the `connectedNode` has no rigid body — the wheel and sign are pinned to the world) needed both constraint partners. Now a static, shapeless anchor body is created at the joint frame's world pose for that side.
- **Shapeless "driver" bodies** (motion but no collider — Robot's `LegDriver` / `CogDriver`) were never created. Now built with an empty container shape and a default inertia.
- Joint body resolution only recognised collider nodes; widened to any node with motion **or** a collider.
- **Joint drives** (motors) are applied best-effort via the raw Havok constraint handle (velocity / position motors), since the Lite wrapper exposes only limits.

Verified against both assets: every joint resolves both frames (WaterWheel 2/2, Robot 19/19) with no missing bodies.

Nodes that render exactly their collider mesh keep the existing subtree path, so **ShapeTypes / JointTypes / MotionProperties** are unaffected.

## Test plan

WebGPU browser (Chrome/Edge 113+):

- WaterWheel — `...?url=https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/WaterWheel/WaterWheel.glb` (wheel turns, screw lifts, parts stay assembled)
- Robot_skinned — `...Robot_skinned/Robot_skinned.glb` (stays assembled, joints hold)
- Regression: ShapeTypes / JointTypes / MotionProperties behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)