### PR TITLE
fix(babylonjs-lite): honor physics material combine modes

### DIFF
--- a/examples/babylonjs-lite/index.js
+++ b/examples/babylonjs-lite/index.js
@@ -829,11 +829,26 @@ async function setupGltfPhysics(scene, json, loadedAsset, glbBin, baseUrl) {
     const root = loadedAsset.entities[0];
     const nodeToTN = buildNodeToTransformNode(json, root);
 
+    // Map a glTF physicsMaterial combine string to a native Havok combine mode.
+    const combineMode = (name, fallback) => {
+        switch (name) {
+            case "average": return combine.ARITHMETIC_MEAN;
+            case "minimum": return combine.MINIMUM;
+            case "maximum": return combine.MAXIMUM;
+            case "multiply": return combine.MULTIPLY;
+            default: return fallback;
+        }
+    };
+    // The Havok material array is [staticFriction, dynamicFriction, restitution, frictionCombine,
+    // restitutionCombine]. Defaults follow the official loader: friction MAXIMUM, restitution MINIMUM.
     const setMaterial = (shape, matIndex) => {
         const matDef = matIndex !== undefined ? materialDefs[matIndex] : null;
-        const friction = matDef?.dynamicFriction ?? 0.5;
+        const staticFriction = matDef?.staticFriction ?? 0.5;
+        const dynamicFriction = matDef?.dynamicFriction ?? 0.5;
         const restitution = matDef?.restitution ?? 0;
-        hknp.HP_Shape_SetMaterial(shape._hkShape, [friction, friction, restitution, combine.MAXIMUM, combine.MAXIMUM]);
+        const frictionCombine = combineMode(matDef?.frictionCombine, combine.MAXIMUM);
+        const restitutionCombine = combineMode(matDef?.restitutionCombine, combine.MINIMUM);
+        hknp.HP_Shape_SetMaterial(shape._hkShape, [staticFriction, dynamicFriction, restitution, frictionCombine, restitutionCombine]);
     };
 
     // Collision filtering (KHR_physics_rigid_bodies collisionFilters), per collider shape. Each named


### PR DESCRIPTION
## Summary

`setMaterial` hardcoded both the friction and restitution **combine modes** to `MAXIMUM`, so the material combine test (`RigidBodies_Materials_01`) bounced **both** balls, diverging from the Babylon.js (full) viewer where only the ball whose material uses `restitutionCombine: "maximum"` bounces.

The test drops two restitution-0.5 balls onto a restitution-0 floor:
- ball 0 — `restitutionCombine: "minimum"` → effective restitution `min(0.5, 0) = 0` → no bounce
- ball 1 — `restitutionCombine: "maximum"` → effective restitution `max(0.5, 0) = 0.5` → bounces

## Fix

Map the glTF `physicsMaterial` `frictionCombine` / `restitutionCombine` strings (`average`/`minimum`/`maximum`/`multiply`) to the native Havok `MaterialCombine` modes, with the official loader's defaults (friction `MAXIMUM`, restitution `MINIMUM`), and pass static / dynamic friction separately.

Verified with a standalone Havok simulation (same `@babylonjs/havok` build): a 0.5-restitution ball on a 0-restitution floor rebounds with `restitutionCombine: "maximum"` (height ≈1.12) but rests without bouncing with `"minimum"`.

## Test plan

WebGPU browser (Chrome/Edge 113+), compare with the Babylon.js (full) viewer:

- `...babylonjs-lite/index.html?url=https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/tests/RigidBodies_Materials/RigidBodies_Materials_01.gltf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)