### PR TITLE
fix(babylonjs-lite): convert motion velocities to the left-handed frame

### DIFF
--- a/examples/babylonjs-lite/index.js
+++ b/examples/babylonjs-lite/index.js
@@ -637,8 +637,11 @@ function applyMotionProperties(world, hknp, body, motion, defaultInertia) {
     if (motion.gravityFactor !== undefined && typeof hknp.HP_Body_SetGravityFactor === 'function') {
         hknp.HP_Body_SetGravityFactor(body._hkBody, motion.gravityFactor);
     }
-    if (Array.isArray(motion.linearVelocity)) setPhysicsBodyLinearVelocity(world, body, { x: motion.linearVelocity[0], y: motion.linearVelocity[1], z: motion.linearVelocity[2] });
-    if (Array.isArray(motion.angularVelocity)) setPhysicsBodyAngularVelocity(world, body, { x: motion.angularVelocity[0], y: motion.angularVelocity[1], z: motion.angularVelocity[2] });
+    // Velocities are in the glTF (right-handed) world frame; convert to the left-handed scene
+    // (F = diag(-1,1,1)). A linear velocity is a true vector (negate X); an angular velocity is a
+    // pseudovector (preserve X, negate Y and Z).
+    if (Array.isArray(motion.linearVelocity)) setPhysicsBodyLinearVelocity(world, body, { x: -motion.linearVelocity[0], y: motion.linearVelocity[1], z: motion.linearVelocity[2] });
+    if (Array.isArray(motion.angularVelocity)) setPhysicsBodyAngularVelocity(world, body, { x: motion.angularVelocity[0], y: -motion.angularVelocity[1], z: -motion.angularVelocity[2] });
 }
 
 // Returns true when the asset declares any KHR_physics_rigid_bodies node bodies.


### PR DESCRIPTION
## Summary

Initial `linearVelocity` / `angularVelocity` from `KHR_physics_rigid_bodies` were applied verbatim. On `RigidBodies_MotionProperties_06` (bodies with `linearVelocity: [5,0,0]`), the bodies drifted along **+X** instead of **−X**, the opposite of the Babylon.js (full) viewer, so they missed the stationary bodies they should collide with.

## Fix

The velocities are expressed in the glTF right-handed world frame; convert them to the scene's left-handed frame (`F = diag(-1,1,1)`), matching the official rigid-body loader (which transforms the velocity by the node's world matrix, and negates the angular velocity for a left-handed scene):

- linear velocity — a true vector → negate X: `[x,y,z] → [-x,y,z]`
- angular velocity — a pseudovector → preserve X, negate Y,Z: `[x,y,z] → [x,-y,-z]`

No regression to existing physics models: WaterWheel's kinematic spinner already applies its own pseudovector flip, and Robot's `LegDriver` angular velocity is about X (unchanged by the Y/Z flip).

## Test plan

WebGPU browser (Chrome/Edge 113+), compare with the Babylon.js (full) viewer:

- `...babylonjs-lite/index.html?url=https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/tests/RigidBodies_MotionProperties/RigidBodies_MotionProperties_06.gltf`
- Regression: MotionProperties / WaterWheel / Robot_skinned behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)