### PR TITLE
feat(babylonjs-lite): skinned ragdoll support (bone-follow skin + scaled centre of mass)

### DIFF
--- a/examples/babylonjs-lite/index.js
+++ b/examples/babylonjs-lite/index.js
@@ -845,84 +845,53 @@ function buildGltfJoints(world, hknp, scene, json, parentMap, jointDefs, bodyByN
 // on the first frame. At the bind pose this reduces to boneMatrix_bind, so there is no pop.
 // Best-effort: any missing internal field disables it for that mesh (skin stays at bind pose).
 function setupSkinnedMeshFollow(scene, engine, json, parentMap, nodeToTN) {
-    const T = (m) => m ? "[" + (+m[12]).toFixed(2) + "," + (+m[13]).toFixed(2) + "," + (+m[14]).toFixed(2) + "]" : "<none>";
     const device = engine?._device;
-    console.log("[skin-debug] setup: device=" + !!device + " skins=" + (json.skins ? json.skins.length : 0));
     if (!device || !json.skins) return;
     for (let nodeIndex = 0; nodeIndex < json.nodes.length; nodeIndex++) {
         const node = json.nodes[nodeIndex];
         if (node.mesh === undefined || node.skin === undefined) continue;
-        const meshObj = nodeToTN.get(nodeIndex);
-        // The mesh renderable (with the skeleton) may be the TN itself or a descendant; search for it.
+        // The skeleton lives on the renderable mesh, which may be the node's transform node or a
+        // descendant of it; search the subtree for the object that carries it.
         let skel = null;
-        let skelHost = null;
         (function walk(n, depth) {
-            if (!n || depth > 4) return;
-            console.log("[skin-debug]   walk d=" + depth + " keys=" + Object.keys(n).join(",")
-                + " _gpu=" + ("_gpu" in n) + " skeleton=" + (n.skeleton !== undefined ? (n.skeleton ? "obj" : "null") : "absent"));
-            if (n.skeleton && !skel) { skel = n.skeleton; skelHost = n; }
+            if (!n || skel || depth > 4) return;
+            if (n.skeleton) { skel = n.skeleton; return; }
             if (Array.isArray(n.children)) for (const c of n.children) walk(c, depth + 1);
-        })(meshObj, 0);
-        console.log("[skin-debug] node " + nodeIndex + " name=" + JSON.stringify(node.name || "") + " mesh=" + node.mesh + " skin=" + node.skin
-            + " meshObj=" + !!meshObj + " foundSkeleton=" + !!skel
-            + " skelKeys=" + (skel ? Object.keys(skel).join(",") : "-"));
-        if (!skel || !skel.boneMatrices || !skel.boneTexture) {
-            console.log("[skin-debug]   SKIP node " + nodeIndex + " (no skeleton/boneMatrices/boneTexture)");
-            continue;
-        }
+        })(nodeToTN.get(nodeIndex), 0);
+        if (!skel || !skel.boneMatrices || !skel.boneTexture) continue;
+
         const skin = json.skins[node.skin];
         const joints = skin && skin.joints;
-        if (!joints || !joints.length) { console.log("[skin-debug]   SKIP node " + nodeIndex + " (no joints)"); continue; }
+        if (!joints || !joints.length) continue;
         const boneNodes = joints.map((j) => nodeToTN.get(j));
-        console.log("[skin-debug]   joints=" + JSON.stringify(joints)
-            + " boneNodesResolved=" + boneNodes.map((b) => !!b).join(",")
-            + " boneNodeHasWorld=" + boneNodes.map((b) => !!(b && b.worldMatrix)).join(",")
-            + " boneMatricesLen=" + skel.boneMatrices.length + " boneCount?=" + skel.boneCount);
-        if (boneNodes.some((b) => !b || !b.worldMatrix)) { console.log("[skin-debug]   SKIP node " + nodeIndex + " (bone node/worldMatrix missing)"); continue; }
+        if (boneNodes.some((b) => !b || !b.worldMatrix)) continue;
 
         const meshWorldBind = applyLeftHandedFlip(nodeWorldMatrix(json, parentMap, nodeIndex));
         const invMeshWorldBind = mat4Invert(meshWorldBind);
-        if (!invMeshWorldBind) { console.log("[skin-debug]   SKIP node " + nodeIndex + " (singular mesh world)"); continue; }
+        if (!invMeshWorldBind) continue;
         // invBindBoneWorld[bi] . meshWorldBind, finished with boneMatrix_bind on the first frame.
-        const bindBoneWorld = joints.map((j) => applyLeftHandedFlip(nodeWorldMatrix(json, parentMap, j)));
-        const partial = bindBoneWorld.map((bw) => {
-            const inv = mat4Invert(bw);
+        const partial = joints.map((j) => {
+            const inv = mat4Invert(applyLeftHandedFlip(nodeWorldMatrix(json, parentMap, j)));
             return inv ? mat4Multiply(inv, meshWorldBind) : null;
         });
-        if (partial.some((p) => !p)) { console.log("[skin-debug]   SKIP node " + nodeIndex + " (singular bind bone world)"); continue; }
-
-        console.log("[skin-debug]   meshWorldBind T=" + T(meshWorldBind) + " bindBoneWorld T=" + bindBoneWorld.map(T).join(" "));
-        console.log("[skin-debug]   REGISTERED skin-follow for node " + nodeIndex);
+        if (partial.some((p) => !p)) continue;
 
         const boneData = skel.boneMatrices;
         const boneCount = joints.length;
         const texWidth = boneCount * 4;
         let rhs = null; // invBindBoneWorld . meshWorld . boneMatrix_bind, per bone (captured once)
-        let frame = 0;
-        const logFrames = new Set([1, 30, 90, 180, 360, 600]);
         onBeforeRender(scene, function() {
             try {
                 if (!rhs) {
                     rhs = partial.map((p, bi) => mat4Multiply(p, boneData.slice(bi * 16, bi * 16 + 16)));
-                    console.log("[skin-debug] node " + nodeIndex + " bind boneMatrix T="
-                        + Array.from({ length: boneCount }, (_, bi) => T(boneData.slice(bi * 16, bi * 16 + 16))).join(" "));
                 }
                 for (let bi = 0; bi < boneCount; bi++) {
                     const toMesh = mat4Multiply(boneNodes[bi].worldMatrix, rhs[bi]);
                     const bm = mat4Multiply(invMeshWorldBind, toMesh);
                     for (let k = 0; k < 16; k++) boneData[bi * 16 + k] = bm[k];
                 }
-                frame++;
-                if (logFrames.has(frame)) {
-                    console.log("[skin-debug] node " + nodeIndex + " frame " + frame
-                        + " meshWorld T=" + T(meshObj.worldMatrix)
-                        + " liveBoneWorld T=" + boneNodes.map((b) => T(b.worldMatrix)).join(" ")
-                        + " boneMatrix_live T=" + Array.from({ length: boneCount }, (_, bi) => T(boneData.slice(bi * 16, bi * 16 + 16))).join(" "));
-                }
                 device.queue.writeTexture({ texture: skel.boneTexture }, boneData.buffer, { bytesPerRow: texWidth * 16 }, { width: texWidth, height: 1 });
-            } catch (e) {
-                console.warn("[skin-debug] node " + nodeIndex + " update error:", e);
-            }
+            } catch (e) { /* keep the last computed pose */ }
         });
     }
 }

--- a/examples/babylonjs-lite/index.js
+++ b/examples/babylonjs-lite/index.js
@@ -662,11 +662,14 @@ function primitiveShapeOptions(shapeDef, absScale) {
 
 // Apply a KHR_physics_rigid_bodies "motion" block to a dynamic body: mass, centre of
 // mass, inertia, gravity factor (negative = floating balloons), and initial velocities.
+// absScale is the body's world scale (magnitude); the centre of mass is given in unscaled
+// node-local units, so it must be scaled to match (the official loader does the same).
 // defaultInertia supplies a fallback inertia for shapeless bodies (empty collider) whose
 // inertia Havok cannot derive from a shape.
-function applyMotionProperties(world, hknp, body, motion, defaultInertia) {
+function applyMotionProperties(world, hknp, body, motion, absScale, defaultInertia) {
+    const s = absScale || [1, 1, 1];
     const massProps = { mass: motion.mass ?? 1 };
-    if (Array.isArray(motion.centerOfMass)) massProps.centerOfMass = { x: motion.centerOfMass[0], y: motion.centerOfMass[1], z: motion.centerOfMass[2] };
+    if (Array.isArray(motion.centerOfMass)) massProps.centerOfMass = { x: motion.centerOfMass[0] * s[0], y: motion.centerOfMass[1] * s[1], z: motion.centerOfMass[2] * s[2] };
     if (Array.isArray(motion.inertiaDiagonal)) massProps.inertia = { x: motion.inertiaDiagonal[0], y: motion.inertiaDiagonal[1], z: motion.inertiaDiagonal[2] };
     else if (defaultInertia) massProps.inertia = { x: 1, y: 1, z: 1 };
     if (Array.isArray(motion.inertiaOrientation)) massProps.inertiaOrientation = { x: motion.inertiaOrientation[0], y: motion.inertiaOrientation[1], z: motion.inertiaOrientation[2], w: motion.inertiaOrientation[3] };
@@ -1059,7 +1062,7 @@ async function setupGltfPhysics(scene, engine, json, loadedAsset, glbBin, baseUr
             }
             const body = createPhysicsBody(world, anchor, PhysicsMotionType.DYNAMIC);
             setPhysicsBodyShape(world, body, container);
-            applyMotionProperties(world, hknp, body, motion);
+            applyMotionProperties(world, hknp, body, motion, lh.scale.map(Math.abs));
             bodies.push(body);
             bodyByNode.set(nodeIndex, { body, scale: lh.scale });
             continue;
@@ -1075,7 +1078,7 @@ async function setupGltfPhysics(scene, engine, json, loadedAsset, glbBin, baseUr
                 const body = createPhysicsBody(world, anchor, isKinematic ? PhysicsMotionType.ANIMATED : PhysicsMotionType.DYNAMIC);
                 setPhysicsBodyShape(world, body, createPhysicsShape(world, { type: PhysicsShapeType.CONTAINER }));
                 if (!isKinematic) {
-                    applyMotionProperties(world, hknp, body, motion, true);
+                    applyMotionProperties(world, hknp, body, motion, lh.scale.map(Math.abs), true);
                 } else if (Array.isArray(motion.angularVelocity)) {
                     spinners.push({ anchor, omega: [motion.angularVelocity[0], -motion.angularVelocity[1], -motion.angularVelocity[2]] });
                 }
@@ -1098,7 +1101,7 @@ async function setupGltfPhysics(scene, engine, json, loadedAsset, glbBin, baseUr
         const body = createPhysicsBody(world, anchor, motionType);
         setPhysicsBodyShape(world, body, shape);
         if (motion && !isKinematic) {
-            applyMotionProperties(world, hknp, body, motion);
+            applyMotionProperties(world, hknp, body, motion, absScale);
         } else if (isKinematic && Array.isArray(motion.angularVelocity)) {
             // Angular velocity is a pseudovector: under F = diag(-1,1,1) it maps (wx,wy,wz)->(wx,-wy,-wz).
             spinners.push({ anchor, omega: [motion.angularVelocity[0], -motion.angularVelocity[1], -motion.angularVelocity[2]] });

--- a/examples/babylonjs-lite/index.js
+++ b/examples/babylonjs-lite/index.js
@@ -898,12 +898,13 @@ function setupSkinnedMeshFollow(scene, engine, json, parentMap, nodeToTN) {
         const boneCount = joints.length;
         const texWidth = boneCount * 4;
         let rhs = null; // invBindBoneWorld . meshWorld . boneMatrix_bind, per bone (captured once)
-        let logged = 0;
+        let frame = 0;
+        const logFrames = new Set([1, 30, 90, 180, 360, 600]);
         onBeforeRender(scene, function() {
             try {
                 if (!rhs) {
                     rhs = partial.map((p, bi) => mat4Multiply(p, boneData.slice(bi * 16, bi * 16 + 16)));
-                    console.log("[skin-debug] node " + nodeIndex + " first frame: boneMatrix_bind T="
+                    console.log("[skin-debug] node " + nodeIndex + " bind boneMatrix T="
                         + Array.from({ length: boneCount }, (_, bi) => T(boneData.slice(bi * 16, bi * 16 + 16))).join(" "));
                 }
                 for (let bi = 0; bi < boneCount; bi++) {
@@ -911,10 +912,10 @@ function setupSkinnedMeshFollow(scene, engine, json, parentMap, nodeToTN) {
                     const bm = mat4Multiply(invMeshWorldBind, toMesh);
                     for (let k = 0; k < 16; k++) boneData[bi * 16 + k] = bm[k];
                 }
-                if (logged < 3) {
-                    logged++;
-                    console.log("[skin-debug] node " + nodeIndex + " frame " + logged
-                        + " meshWorldLive T=" + T(meshObj.worldMatrix)
+                frame++;
+                if (logFrames.has(frame)) {
+                    console.log("[skin-debug] node " + nodeIndex + " frame " + frame
+                        + " meshWorld T=" + T(meshObj.worldMatrix)
                         + " liveBoneWorld T=" + boneNodes.map((b) => T(b.worldMatrix)).join(" ")
                         + " boneMatrix_live T=" + Array.from({ length: boneCount }, (_, bi) => T(boneData.slice(bi * 16, bi * 16 + 16))).join(" "));
                 }

--- a/examples/babylonjs-lite/index.js
+++ b/examples/babylonjs-lite/index.js
@@ -853,11 +853,18 @@ function setupSkinnedMeshFollow(scene, engine, json, parentMap, nodeToTN) {
         const node = json.nodes[nodeIndex];
         if (node.mesh === undefined || node.skin === undefined) continue;
         const meshObj = nodeToTN.get(nodeIndex);
-        const skel = meshObj && meshObj.skeleton;
+        // The mesh renderable (with the skeleton) may be the TN itself or a descendant; search for it.
+        let skel = null;
+        let skelHost = null;
+        (function walk(n, depth) {
+            if (!n || depth > 4) return;
+            console.log("[skin-debug]   walk d=" + depth + " keys=" + Object.keys(n).join(",")
+                + " _gpu=" + ("_gpu" in n) + " skeleton=" + (n.skeleton !== undefined ? (n.skeleton ? "obj" : "null") : "absent"));
+            if (n.skeleton && !skel) { skel = n.skeleton; skelHost = n; }
+            if (Array.isArray(n.children)) for (const c of n.children) walk(c, depth + 1);
+        })(meshObj, 0);
         console.log("[skin-debug] node " + nodeIndex + " name=" + JSON.stringify(node.name || "") + " mesh=" + node.mesh + " skin=" + node.skin
-            + " meshObj=" + !!meshObj
-            + " meshObjKeys=" + (meshObj ? Object.keys(meshObj).join(",") : "-")
-            + " skeleton=" + !!skel
+            + " meshObj=" + !!meshObj + " foundSkeleton=" + !!skel
             + " skelKeys=" + (skel ? Object.keys(skel).join(",") : "-"));
         if (!skel || !skel.boneMatrices || !skel.boneTexture) {
             console.log("[skin-debug]   SKIP node " + nodeIndex + " (no skeleton/boneMatrices/boneTexture)");

--- a/examples/babylonjs-lite/index.js
+++ b/examples/babylonjs-lite/index.js
@@ -399,6 +399,45 @@ function buildColliderMeshFromGltf(json, buffers, meshIndex, scale) {
     };
 }
 
+// Read a MAT4 FLOAT accessor (e.g. inverseBindMatrices) as a flat Float32Array (16 per element).
+function readAccessorMat4(json, buffers, accessorIndex) {
+    const acc = json.accessors[accessorIndex];
+    const bv = json.bufferViews[acc.bufferView];
+    const dv = new DataView(buffers[bv.buffer]);
+    const base = (bv.byteOffset || 0) + (acc.byteOffset || 0);
+    const out = new Float32Array(acc.count * 16);
+    for (let i = 0; i < acc.count * 16; i++) {
+        out[i] = dv.getFloat32(base + i * 4, true);
+    }
+    return out;
+}
+
+// Invert a column-major 4x4 matrix (16-element array). Returns null when singular.
+function mat4Invert(m) {
+    const inv = new Array(16);
+    inv[0] = m[5]*m[10]*m[15] - m[5]*m[11]*m[14] - m[9]*m[6]*m[15] + m[9]*m[7]*m[14] + m[13]*m[6]*m[11] - m[13]*m[7]*m[10];
+    inv[4] = -m[4]*m[10]*m[15] + m[4]*m[11]*m[14] + m[8]*m[6]*m[15] - m[8]*m[7]*m[14] - m[12]*m[6]*m[11] + m[12]*m[7]*m[10];
+    inv[8] = m[4]*m[9]*m[15] - m[4]*m[11]*m[13] - m[8]*m[5]*m[15] + m[8]*m[7]*m[13] + m[12]*m[5]*m[11] - m[12]*m[7]*m[9];
+    inv[12] = -m[4]*m[9]*m[14] + m[4]*m[10]*m[13] + m[8]*m[5]*m[14] - m[8]*m[6]*m[13] - m[12]*m[5]*m[10] + m[12]*m[6]*m[9];
+    inv[1] = -m[1]*m[10]*m[15] + m[1]*m[11]*m[14] + m[9]*m[2]*m[15] - m[9]*m[3]*m[14] - m[13]*m[2]*m[11] + m[13]*m[3]*m[10];
+    inv[5] = m[0]*m[10]*m[15] - m[0]*m[11]*m[14] - m[8]*m[2]*m[15] + m[8]*m[3]*m[14] + m[12]*m[2]*m[11] - m[12]*m[3]*m[10];
+    inv[9] = -m[0]*m[9]*m[15] + m[0]*m[11]*m[13] + m[8]*m[1]*m[15] - m[8]*m[3]*m[13] - m[12]*m[1]*m[11] + m[12]*m[3]*m[9];
+    inv[13] = m[0]*m[9]*m[14] - m[0]*m[10]*m[13] - m[8]*m[1]*m[14] + m[8]*m[2]*m[13] + m[12]*m[1]*m[10] - m[12]*m[2]*m[9];
+    inv[2] = m[1]*m[6]*m[15] - m[1]*m[7]*m[14] - m[5]*m[2]*m[15] + m[5]*m[3]*m[14] + m[13]*m[2]*m[7] - m[13]*m[3]*m[6];
+    inv[6] = -m[0]*m[6]*m[15] + m[0]*m[7]*m[14] + m[4]*m[2]*m[15] - m[4]*m[3]*m[14] - m[12]*m[2]*m[7] + m[12]*m[3]*m[6];
+    inv[10] = m[0]*m[5]*m[15] - m[0]*m[7]*m[13] - m[4]*m[1]*m[15] + m[4]*m[3]*m[13] + m[12]*m[1]*m[7] - m[12]*m[3]*m[5];
+    inv[14] = -m[0]*m[5]*m[14] + m[0]*m[6]*m[13] + m[4]*m[1]*m[14] - m[4]*m[2]*m[13] - m[12]*m[1]*m[6] + m[12]*m[2]*m[5];
+    inv[3] = -m[1]*m[6]*m[11] + m[1]*m[7]*m[10] + m[5]*m[2]*m[11] - m[5]*m[3]*m[10] - m[9]*m[2]*m[7] + m[9]*m[3]*m[6];
+    inv[7] = m[0]*m[6]*m[11] - m[0]*m[7]*m[10] - m[4]*m[2]*m[11] + m[4]*m[3]*m[10] + m[8]*m[2]*m[7] - m[8]*m[3]*m[6];
+    inv[11] = -m[0]*m[5]*m[11] + m[0]*m[7]*m[9] + m[4]*m[1]*m[11] - m[4]*m[3]*m[9] - m[8]*m[1]*m[7] + m[8]*m[3]*m[5];
+    inv[15] = m[0]*m[5]*m[10] - m[0]*m[6]*m[9] - m[4]*m[1]*m[10] + m[4]*m[2]*m[9] + m[8]*m[1]*m[6] - m[8]*m[2]*m[5];
+    let det = m[0]*inv[0] + m[1]*inv[4] + m[2]*inv[8] + m[3]*inv[12];
+    if (det === 0) return null;
+    det = 1 / det;
+    for (let i = 0; i < 16; i++) inv[i] *= det;
+    return inv;
+}
+
 // Parse the cameras from a glTF JSON object and return their world positions
 // (in glTF right-handed coordinates) together with per-camera perspective params.
 // Returns [] when no cameras are defined in the file.
@@ -794,10 +833,52 @@ function buildGltfJoints(world, hknp, scene, json, parentMap, jointDefs, bodyByN
     }
 }
 
+// Skinned meshes deform from Lite's animation system, not from live node transforms, so a skin bound
+// to physics-driven bones (a ragdoll, e.g. Robot_skinned) stays at its bind pose while the bones move.
+// Recompute each skin's bone matrices from the live bone world transforms every frame and re-upload
+// its bone texture so the skin follows the physics bodies. Mirrors Lite's own bone-matrix formula
+// (invMeshWorld * boneWorld * inverseBindMatrix), so at bind pose the result is identical (no jump).
+// Best-effort: any missing internal field disables it for that mesh (skin stays at bind pose).
+function setupSkinnedMeshFollow(scene, engine, json, buffers, nodeToTN) {
+    const device = engine?._device;
+    if (!device || !buffers || !json.skins) return;
+    for (let nodeIndex = 0; nodeIndex < json.nodes.length; nodeIndex++) {
+        const node = json.nodes[nodeIndex];
+        if (node.mesh === undefined || node.skin === undefined) continue;
+        const meshObj = nodeToTN.get(nodeIndex);
+        const skel = meshObj && meshObj.skeleton;
+        if (!skel || !skel.boneMatrices || !skel.boneTexture) continue;
+        const skin = json.skins[node.skin];
+        const joints = skin && skin.joints;
+        if (!joints || !joints.length) continue;
+        const boneNodes = joints.map((j) => nodeToTN.get(j));
+        if (boneNodes.some((b) => !b || !b.worldMatrix)) continue;
+        let ibm = null;
+        try {
+            if (skin.inverseBindMatrices !== undefined) ibm = readAccessorMat4(json, buffers, skin.inverseBindMatrices);
+        } catch (e) { continue; }
+        const boneData = skel.boneMatrices;
+        const boneCount = joints.length;
+        const texWidth = boneCount * 4;
+        onBeforeRender(scene, function() {
+            try {
+                const invMesh = mat4Invert(meshObj.worldMatrix);
+                if (!invMesh) return;
+                for (let bi = 0; bi < boneCount; bi++) {
+                    const toMesh = mat4Multiply(invMesh, boneNodes[bi].worldMatrix);
+                    const bm = ibm ? mat4Multiply(toMesh, ibm.subarray(bi * 16, bi * 16 + 16)) : toMesh;
+                    for (let k = 0; k < 16; k++) boneData[bi * 16 + k] = bm[k];
+                }
+                device.queue.writeTexture({ texture: skel.boneTexture }, boneData.buffer, { bytesPerRow: texWidth * 16 }, { width: texWidth, height: 1 });
+            } catch (e) { /* keep the last computed pose */ }
+        });
+    }
+}
+
 // Build Havok rigid bodies from a model's glTF physics extensions and reparent the
 // matching visual subtrees under physics anchors so they follow the simulation.
 // Returns { world, viewer, bodies } or null when the asset has no physics.
-async function setupGltfPhysics(scene, json, loadedAsset, glbBin, baseUrl) {
+async function setupGltfPhysics(scene, engine, json, loadedAsset, glbBin, baseUrl) {
     const shapeDefs = json.extensions?.KHR_implicit_shapes?.shapes || [];
     const scenePhysics = json.extensions?.KHR_physics_rigid_bodies || {};
     const materialDefs = scenePhysics.physicsMaterials || [];
@@ -806,10 +887,12 @@ async function setupGltfPhysics(scene, json, loadedAsset, glbBin, baseUrl) {
     const parentMap = buildParentMap(json);
 
     // Collider meshes the visual loader never instantiates (collision-only, or a mesh index
-    // differing from the node's own) must be decoded straight from the glTF buffers.
+    // differing from the node's own) must be decoded straight from the glTF buffers; skinned meshes
+    // bound to physics bones also need the buffers (for their inverse bind matrices).
     const needsBuffers = json.nodes.some(function(n) {
         const g = n.extensions?.KHR_physics_rigid_bodies?.collider?.geometry;
-        return g && g.shape === undefined && g.mesh !== undefined && n.mesh !== g.mesh;
+        if (g && g.shape === undefined && g.mesh !== undefined && n.mesh !== g.mesh) return true;
+        return n.mesh !== undefined && n.skin !== undefined;
     });
     let buffers = null;
     if (needsBuffers) {
@@ -1024,6 +1107,9 @@ async function setupGltfPhysics(scene, json, loadedAsset, glbBin, baseUrl) {
         });
     }
 
+    // Make skinned meshes (ragdolls) follow their physics-driven bones.
+    setupSkinnedMeshFollow(scene, engine, json, buffers, nodeToTN);
+
     if (params.PHYSICS_DEBUG) {
         for (const body of bodies) showPhysicsBody(viewer, body);
     }
@@ -1072,7 +1158,7 @@ async function createScene(engine, modelSource) {
     if (hasGltfPhysics(gltfJson)) {
         scene.fixedDeltaMs = 1000 / PHYSICS_FPS;
         try {
-            physicsData = await setupGltfPhysics(scene, gltfJson, loadedAsset, gltfAsset.glbBin, absolutePath);
+            physicsData = await setupGltfPhysics(scene, engine, gltfJson, loadedAsset, gltfAsset.glbBin, absolutePath);
         } catch (error) {
             console.error("[glTF Physics] Failed to set up physics:", error);
         }

--- a/examples/babylonjs-lite/index.js
+++ b/examples/babylonjs-lite/index.js
@@ -845,46 +845,76 @@ function buildGltfJoints(world, hknp, scene, json, parentMap, jointDefs, bodyByN
 // on the first frame. At the bind pose this reduces to boneMatrix_bind, so there is no pop.
 // Best-effort: any missing internal field disables it for that mesh (skin stays at bind pose).
 function setupSkinnedMeshFollow(scene, engine, json, parentMap, nodeToTN) {
+    const T = (m) => m ? "[" + (+m[12]).toFixed(2) + "," + (+m[13]).toFixed(2) + "," + (+m[14]).toFixed(2) + "]" : "<none>";
     const device = engine?._device;
+    console.log("[skin-debug] setup: device=" + !!device + " skins=" + (json.skins ? json.skins.length : 0));
     if (!device || !json.skins) return;
     for (let nodeIndex = 0; nodeIndex < json.nodes.length; nodeIndex++) {
         const node = json.nodes[nodeIndex];
         if (node.mesh === undefined || node.skin === undefined) continue;
         const meshObj = nodeToTN.get(nodeIndex);
         const skel = meshObj && meshObj.skeleton;
-        if (!skel || !skel.boneMatrices || !skel.boneTexture) continue;
+        console.log("[skin-debug] node " + nodeIndex + " name=" + JSON.stringify(node.name || "") + " mesh=" + node.mesh + " skin=" + node.skin
+            + " meshObj=" + !!meshObj
+            + " meshObjKeys=" + (meshObj ? Object.keys(meshObj).join(",") : "-")
+            + " skeleton=" + !!skel
+            + " skelKeys=" + (skel ? Object.keys(skel).join(",") : "-"));
+        if (!skel || !skel.boneMatrices || !skel.boneTexture) {
+            console.log("[skin-debug]   SKIP node " + nodeIndex + " (no skeleton/boneMatrices/boneTexture)");
+            continue;
+        }
         const skin = json.skins[node.skin];
         const joints = skin && skin.joints;
-        if (!joints || !joints.length) continue;
+        if (!joints || !joints.length) { console.log("[skin-debug]   SKIP node " + nodeIndex + " (no joints)"); continue; }
         const boneNodes = joints.map((j) => nodeToTN.get(j));
-        if (boneNodes.some((b) => !b || !b.worldMatrix)) continue;
+        console.log("[skin-debug]   joints=" + JSON.stringify(joints)
+            + " boneNodesResolved=" + boneNodes.map((b) => !!b).join(",")
+            + " boneNodeHasWorld=" + boneNodes.map((b) => !!(b && b.worldMatrix)).join(",")
+            + " boneMatricesLen=" + skel.boneMatrices.length + " boneCount?=" + skel.boneCount);
+        if (boneNodes.some((b) => !b || !b.worldMatrix)) { console.log("[skin-debug]   SKIP node " + nodeIndex + " (bone node/worldMatrix missing)"); continue; }
 
         const meshWorldBind = applyLeftHandedFlip(nodeWorldMatrix(json, parentMap, nodeIndex));
         const invMeshWorldBind = mat4Invert(meshWorldBind);
-        if (!invMeshWorldBind) continue;
+        if (!invMeshWorldBind) { console.log("[skin-debug]   SKIP node " + nodeIndex + " (singular mesh world)"); continue; }
         // invBindBoneWorld[bi] . meshWorldBind, finished with boneMatrix_bind on the first frame.
-        const partial = joints.map((j) => {
-            const inv = mat4Invert(applyLeftHandedFlip(nodeWorldMatrix(json, parentMap, j)));
+        const bindBoneWorld = joints.map((j) => applyLeftHandedFlip(nodeWorldMatrix(json, parentMap, j)));
+        const partial = bindBoneWorld.map((bw) => {
+            const inv = mat4Invert(bw);
             return inv ? mat4Multiply(inv, meshWorldBind) : null;
         });
-        if (partial.some((p) => !p)) continue;
+        if (partial.some((p) => !p)) { console.log("[skin-debug]   SKIP node " + nodeIndex + " (singular bind bone world)"); continue; }
+
+        console.log("[skin-debug]   meshWorldBind T=" + T(meshWorldBind) + " bindBoneWorld T=" + bindBoneWorld.map(T).join(" "));
+        console.log("[skin-debug]   REGISTERED skin-follow for node " + nodeIndex);
 
         const boneData = skel.boneMatrices;
         const boneCount = joints.length;
         const texWidth = boneCount * 4;
         let rhs = null; // invBindBoneWorld . meshWorld . boneMatrix_bind, per bone (captured once)
+        let logged = 0;
         onBeforeRender(scene, function() {
             try {
                 if (!rhs) {
                     rhs = partial.map((p, bi) => mat4Multiply(p, boneData.slice(bi * 16, bi * 16 + 16)));
+                    console.log("[skin-debug] node " + nodeIndex + " first frame: boneMatrix_bind T="
+                        + Array.from({ length: boneCount }, (_, bi) => T(boneData.slice(bi * 16, bi * 16 + 16))).join(" "));
                 }
                 for (let bi = 0; bi < boneCount; bi++) {
                     const toMesh = mat4Multiply(boneNodes[bi].worldMatrix, rhs[bi]);
                     const bm = mat4Multiply(invMeshWorldBind, toMesh);
                     for (let k = 0; k < 16; k++) boneData[bi * 16 + k] = bm[k];
                 }
+                if (logged < 3) {
+                    logged++;
+                    console.log("[skin-debug] node " + nodeIndex + " frame " + logged
+                        + " meshWorldLive T=" + T(meshObj.worldMatrix)
+                        + " liveBoneWorld T=" + boneNodes.map((b) => T(b.worldMatrix)).join(" ")
+                        + " boneMatrix_live T=" + Array.from({ length: boneCount }, (_, bi) => T(boneData.slice(bi * 16, bi * 16 + 16))).join(" "));
+                }
                 device.queue.writeTexture({ texture: skel.boneTexture }, boneData.buffer, { bytesPerRow: texWidth * 16 }, { width: texWidth, height: 1 });
-            } catch (e) { /* keep the last computed pose */ }
+            } catch (e) {
+                console.warn("[skin-debug] node " + nodeIndex + " update error:", e);
+            }
         });
     }
 }

--- a/examples/babylonjs-lite/index.js
+++ b/examples/babylonjs-lite/index.js
@@ -835,13 +835,18 @@ function buildGltfJoints(world, hknp, scene, json, parentMap, jointDefs, bodyByN
 
 // Skinned meshes deform from Lite's animation system, not from live node transforms, so a skin bound
 // to physics-driven bones (a ragdoll, e.g. Robot_skinned) stays at its bind pose while the bones move.
-// Recompute each skin's bone matrices from the live bone world transforms every frame and re-upload
-// its bone texture so the skin follows the physics bodies. Mirrors Lite's own bone-matrix formula
-// (invMeshWorld * boneWorld * inverseBindMatrix), so at bind pose the result is identical (no jump).
+// Each frame, nudge every bone matrix by the bone's world-space motion since the bind pose and
+// re-upload the bone texture so the skin follows the physics bodies.
+//
+// A convention-agnostic delta keeps us independent of how Lite stores its inverse bind matrices:
+//   boneMatrix_live = invMeshWorld . liveBoneWorld . invBindBoneWorld . meshWorld . boneMatrix_bind
+// Bind matrices (meshWorld/boneWorld) are taken from the glTF, left-hand-flipped exactly like the
+// physics bodies (F = diag(-1,1,1) = Lite's RH_TO_LH); boneMatrix_bind is Lite's own value captured
+// on the first frame. At the bind pose this reduces to boneMatrix_bind, so there is no pop.
 // Best-effort: any missing internal field disables it for that mesh (skin stays at bind pose).
-function setupSkinnedMeshFollow(scene, engine, json, buffers, nodeToTN) {
+function setupSkinnedMeshFollow(scene, engine, json, parentMap, nodeToTN) {
     const device = engine?._device;
-    if (!device || !buffers || !json.skins) return;
+    if (!device || !json.skins) return;
     for (let nodeIndex = 0; nodeIndex < json.nodes.length; nodeIndex++) {
         const node = json.nodes[nodeIndex];
         if (node.mesh === undefined || node.skin === undefined) continue;
@@ -853,20 +858,29 @@ function setupSkinnedMeshFollow(scene, engine, json, buffers, nodeToTN) {
         if (!joints || !joints.length) continue;
         const boneNodes = joints.map((j) => nodeToTN.get(j));
         if (boneNodes.some((b) => !b || !b.worldMatrix)) continue;
-        let ibm = null;
-        try {
-            if (skin.inverseBindMatrices !== undefined) ibm = readAccessorMat4(json, buffers, skin.inverseBindMatrices);
-        } catch (e) { continue; }
+
+        const meshWorldBind = applyLeftHandedFlip(nodeWorldMatrix(json, parentMap, nodeIndex));
+        const invMeshWorldBind = mat4Invert(meshWorldBind);
+        if (!invMeshWorldBind) continue;
+        // invBindBoneWorld[bi] . meshWorldBind, finished with boneMatrix_bind on the first frame.
+        const partial = joints.map((j) => {
+            const inv = mat4Invert(applyLeftHandedFlip(nodeWorldMatrix(json, parentMap, j)));
+            return inv ? mat4Multiply(inv, meshWorldBind) : null;
+        });
+        if (partial.some((p) => !p)) continue;
+
         const boneData = skel.boneMatrices;
         const boneCount = joints.length;
         const texWidth = boneCount * 4;
+        let rhs = null; // invBindBoneWorld . meshWorld . boneMatrix_bind, per bone (captured once)
         onBeforeRender(scene, function() {
             try {
-                const invMesh = mat4Invert(meshObj.worldMatrix);
-                if (!invMesh) return;
+                if (!rhs) {
+                    rhs = partial.map((p, bi) => mat4Multiply(p, boneData.slice(bi * 16, bi * 16 + 16)));
+                }
                 for (let bi = 0; bi < boneCount; bi++) {
-                    const toMesh = mat4Multiply(invMesh, boneNodes[bi].worldMatrix);
-                    const bm = ibm ? mat4Multiply(toMesh, ibm.subarray(bi * 16, bi * 16 + 16)) : toMesh;
+                    const toMesh = mat4Multiply(boneNodes[bi].worldMatrix, rhs[bi]);
+                    const bm = mat4Multiply(invMeshWorldBind, toMesh);
                     for (let k = 0; k < 16; k++) boneData[bi * 16 + k] = bm[k];
                 }
                 device.queue.writeTexture({ texture: skel.boneTexture }, boneData.buffer, { bytesPerRow: texWidth * 16 }, { width: texWidth, height: 1 });
@@ -887,12 +901,10 @@ async function setupGltfPhysics(scene, engine, json, loadedAsset, glbBin, baseUr
     const parentMap = buildParentMap(json);
 
     // Collider meshes the visual loader never instantiates (collision-only, or a mesh index
-    // differing from the node's own) must be decoded straight from the glTF buffers; skinned meshes
-    // bound to physics bones also need the buffers (for their inverse bind matrices).
+    // differing from the node's own) must be decoded straight from the glTF buffers.
     const needsBuffers = json.nodes.some(function(n) {
         const g = n.extensions?.KHR_physics_rigid_bodies?.collider?.geometry;
-        if (g && g.shape === undefined && g.mesh !== undefined && n.mesh !== g.mesh) return true;
-        return n.mesh !== undefined && n.skin !== undefined;
+        return g && g.shape === undefined && g.mesh !== undefined && n.mesh !== g.mesh;
     });
     let buffers = null;
     if (needsBuffers) {
@@ -1108,7 +1120,7 @@ async function setupGltfPhysics(scene, engine, json, loadedAsset, glbBin, baseUr
     }
 
     // Make skinned meshes (ragdolls) follow their physics-driven bones.
-    setupSkinnedMeshFollow(scene, engine, json, buffers, nodeToTN);
+    setupSkinnedMeshFollow(scene, engine, json, parentMap, nodeToTN);
 
     if (params.PHYSICS_DEBUG) {
         for (const body of bodies) showPhysicsBody(viewer, body);


### PR DESCRIPTION
## Summary

Makes the **Robot_skinned** ragdoll render correctly in the Babylon.js Lite viewer (verified: the robot now stands on the floor and animates). Two fixes:

### 1. Skinned mesh follows its physics-driven bones

The robot's torso is a skinned mesh bound to two bones that are children of the body and head rigid bodies. Lite computes skin bone matrices from its **animation** system, and this asset has no animation, so the torso stayed at its bind pose while the physics bones moved.

Each frame, nudge every bone matrix by the bone's world-space motion since the bind pose and re-upload the bone texture. A convention-agnostic delta keeps it independent of how Lite encodes inverse bind matrices:

```
boneMatrix_live = invMeshWorld . liveBoneWorld . invBindBoneWorld . meshWorld . boneMatrix_bind
```

`boneMatrix_bind` is Lite's own value (captured on the first frame); bind world matrices come from the glTF, left-hand-flipped like the physics bodies. At the bind pose this reduces to `boneMatrix_bind` (no pop); numerically verified. The skeleton lives on the renderable mesh (a descendant of the node's transform node), so it is located by walking the subtree. Best-effort and fully guarded.

### 2. Centre of mass scaled by the node's world scale

A motion's `centerOfMass` is in unscaled node-local units. Robot's legs use scale `0.01` with a `centerOfMass` of `[0,-4.53,-3.75]`, so applying it verbatim placed the mass centre ~100x too far out and the legs sank through the floor. Now multiplied by the body's world scale, matching the official loader (`centerOfMass.multiplyInPlace(absoluteScaling)`).

## Test plan

WebGPU browser (Chrome/Edge 113+), compare with the Babylon.js (full) viewer:

- `...babylonjs-lite/index.html?url=https://raw.githubusercontent.com/eoineoineoin/glTF_Physics/master/samples/Robot_skinned/Robot_skinned.glb`
- Regression: other physics models are unaffected — non-skinned models skip the skin-follow code, and the centre-of-mass scaling is a no-op for unit-scale bodies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)