### PR TITLE
feat(babylonjs-lite): match the babylonjs viewer's default camera framing

### DIFF
--- a/examples/babylonjs-lite/index.js
+++ b/examples/babylonjs-lite/index.js
@@ -5,6 +5,7 @@ import {
     loadGltf,
     addToScene,
     createDefaultCamera,
+    createArcRotateCamera,
     attachControl,
     loadEnvironment,
     startEngine,
@@ -1191,14 +1192,27 @@ async function createScene(engine, modelSource) {
     addToScene(scene, light1);
     addToScene(scene, light2);
 
-    const cam = createDefaultCamera(scene);
-    // Lite default is alpha=-π/2 (camera at -Z); match babylonjs_webgpu which
-    // uses setPosition(0,3,5), equivalent to alpha=+π/2 (camera at +Z, front view).
-    cam.alpha = Math.PI / 2;
-    // createDefaultCamera auto-sizes farPlane to radius*1000. For small models
-    // (e.g. Triangle, radius≈2) this gives farPlane≈2000, clipping the 10000-unit
-    // skybox. Ensure a minimum that always covers it.
-    cam.farPlane = Math.max(cam.farPlane, 20000);
+    let cam;
+    if (modelInfo) {
+        // Indexed / URL models: match the babylonjs (full) viewer's framing instead of auto-fitting
+        // the bounding box — an ArcRotateCamera looking at the origin from (0, 3/scale, 5/scale),
+        // where `scale` is the per-model camera-distance hint from the model index (default 1).
+        // Lite's eye = target + radius·(cosα·sinβ, cosβ, sinα·sinβ); solving for that position gives
+        // α = +π/2 (camera on +Z, front view), β = atan2(5,3), radius = √34 / scale.
+        const scale = modelInfo.scale || 1;
+        const camRadius = Math.sqrt(34) / scale;
+        cam = createArcRotateCamera(Math.PI / 2, Math.atan2(5, 3), camRadius, { x: 0, y: 0, z: 0 });
+        scene.camera = cam;
+        // Near relative to distance (matches the full viewer's reduced near plane); far always
+        // covers the 10000-unit skybox.
+        cam.nearPlane = camRadius * 0.01;
+        cam.farPlane = Math.max(camRadius * 1000, 20000);
+    } else {
+        // Drag-dropped models have no scale hint, so auto-fit to the bounding box and view from +Z.
+        cam = createDefaultCamera(scene);
+        cam.alpha = Math.PI / 2;
+        cam.farPlane = Math.max(cam.farPlane, 20000);
+    }
     attachControl(cam, canvas, scene);
 
     // Snapshot default camera pose so the GUI can reset to it.


### PR DESCRIPTION
## Summary

The Babylon.js Lite glTF viewer auto-fit the camera to each model's bounding box, so its default view differed from the **babylonjs (full)** viewer (and the rest of the comparison suite, which all use the same `scale`-based framing).

For **indexed / URL** models, the camera now frames the model the same way as the full viewer: an `ArcRotateCamera` looking at the origin from position `(0, 3/scale, 5/scale)`, using the model index's per-model `scale` hint.

The full viewer does `camera.setPosition(0/scale, 3/scale, 5/scale)` with target = origin. Solving Lite's `eye = target + radius·(cosα·sinβ, cosβ, sinα·sinβ)` for that position gives:

- `alpha = +π/2` (camera on +Z, front view)
- `beta = atan2(5, 3)`
- `radius = √34 / scale`

Verified numerically that this reproduces `(0, 3/scale, 5/scale)` for scale = 1, 0.5, 0.005.

**Drag-dropped** models have no `scale` hint, so they keep the bounding-box auto-fit (better UX for arbitrary files).

## Notes on interactive controls

- **Orbit** speed/direction already matched (both use angular sensibility 1000).
- **Zoom / pan** speed differs (Lite's `attachControl` hardcodes `wheelPrecision`/`panningSensibility`; the full viewer uses `wheelDeltaPercentage = 0.005`). Matching those exactly would require a custom control implementation — happy to follow up if desired.

## Test plan

WebGPU browser (Chrome/Edge 113+), compare default view with the babylonjs (full) viewer across several models, e.g.:

- `...babylonjs-lite/index.html?model=Duck`
- `...babylonjs-lite/index.html?model=2CylinderEngine&scale=0.005`
- Drag-and-drop a local model → still auto-frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)