### PR TITLE
fix(babylon-lite): load Babylon Lite from esm.sh instead of jsDelivr

### DIFF
--- a/examples/babylon-lite/index.html
+++ b/examples/babylon-lite/index.html
@@ -4,11 +4,13 @@
 <meta charset="UTF-8" />
 <link rel="stylesheet" type="text/css" media="screen,print" href="style.css" />
 <title>[WebGPU] Babylon Lite + glTFLoader</title>
+
+<!-- @babylonjs/lite v1.4.0 (loaded via importmap) -->
 <script type="importmap">
 {
   "imports": {
-    "babylon-lite": "https://cdn.jsdelivr.net/npm/@babylonjs/lite@1.4.0",
-    "@babylonjs/havok": "https://cdn.jsdelivr.net/npm/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
+    "babylon-lite": "https://esm.sh/@babylonjs/lite@1.4.0",
+    "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }
 </script>
@@ -22,7 +24,6 @@
 <script src="../../tutorialModels/wip-extension-test-model-index.js"></script>
 </head>
 <body>
-<!-- @babylonjs/lite v1.0.1 (loaded via importmap) -->
 
 <!-- dat.gui.js -->
 <script src="../../libs/common/dat.gui.js"></script>

--- a/examples/babylon-lite/index.js
+++ b/examples/babylon-lite/index.js
@@ -40,7 +40,7 @@ import {
 import HavokPhysics from "@babylonjs/havok";
 
 const ENV_URL = "../../textures/env/papermillSpecularHDR.env";
-const BRDF_URL = "https://cdn.jsdelivr.net/gh/BabylonJS/Babylon-Lite@master/packages/babylon-lite/assets/brdf-lut.png";
+const BRDF_URL = "https://esm.sh/gh/BabylonJS/Babylon-Lite@master/packages/babylon-lite/assets/brdf-lut.png";
 
 // Physics simulation step rate for KHR_physics_rigid_bodies models.
 const PHYSICS_FPS = 60;


### PR DESCRIPTION
## Summary

The Babylon Lite glTF viewer loaded `@babylonjs/lite` from `cdn.jsdelivr.net`, which resolves the bare specifier to `dist/index.js` — a legacy bundle with hardcoded `VERSION` metadata. As a result the console reported the **wrong Babylon Lite version**.

`esm.sh` respects the package `exports` map and loads `lib/index.js`, which carries the correct version info.

## Changes

- `examples/babylon-lite/index.html` — importmap (`@babylonjs/lite`, `@babylonjs/havok`) switched to `esm.sh`; version comment relocated above the importmap and corrected to `v1.4.0`
- `examples/babylon-lite/index.js` — `brdf-lut.png` URL switched to `esm.sh`

This mirrors cx20/webgl-physics-examples#460, which applied the same migration to the Babylon Lite Havok examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)