### PR TITLE
feat(babylon-lite): bump @babylonjs/lite to 1.8.0

### DIFF
--- a/examples/babylon-lite/index.html
+++ b/examples/babylon-lite/index.html
@@ -5,11 +5,11 @@
 <link rel="stylesheet" type="text/css" media="screen,print" href="style.css" />
 <title>[WebGPU] Babylon Lite + glTFLoader</title>
 
-<!-- @babylonjs/lite v1.7.0 (loaded via importmap) -->
+<!-- @babylonjs/lite v1.8.0 (loaded via importmap) -->
 <script type="importmap">
 {
   "imports": {
-    "babylon-lite": "https://esm.sh/@babylonjs/lite@1.7.0?bundle",
+    "babylon-lite": "https://esm.sh/@babylonjs/lite@1.8.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }


### PR DESCRIPTION
## Summary
Update Babylon Lite from 1.7.0 to 1.8.0 in the babylon-lite example.

- `examples/babylon-lite/index.html`: importmap URL `@babylonjs/lite@1.7.0?bundle` → `@babylonjs/lite@1.8.0?bundle` (and matching version comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)