### PR TITLE
Update Babylon Lite to 1.13.0 and match CubeMap-off background

### DIFF
--- a/examples/babylon-lite/index.html
+++ b/examples/babylon-lite/index.html
@@ -5,11 +5,11 @@
 <link rel="stylesheet" type="text/css" media="screen,print" href="style.css" />
 <title>[WebGPU] Babylon Lite + glTFLoader</title>
 
-<!-- @babylonjs/lite v1.10.0 (loaded via importmap) -->
+<!-- @babylonjs/lite v1.13.0 (loaded via importmap) -->
 <script type="importmap">
 {
   "imports": {
-    "babylon-lite": "https://esm.sh/@babylonjs/lite@1.10.0?bundle",
+    "babylon-lite": "https://esm.sh/@babylonjs/lite@1.13.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }

--- a/examples/babylon-lite/index.js
+++ b/examples/babylon-lite/index.js
@@ -45,6 +45,8 @@ import HavokPhysics from "@babylonjs/havok";
 
 const ENV_URL = "../../textures/env/papermillSpecularHDR.env";
 const BRDF_URL = "https://esm.sh/gh/BabylonJS/Babylon-Lite@master/packages/babylon-lite/assets/brdf-lut.png";
+const CLEAR_COLOR_CUBEMAP_ON = { r: 1, g: 1, b: 1, a: 1 };
+const CLEAR_COLOR_CUBEMAP_OFF = { r: 0.23, g: 0.23, b: 0.35, a: 1 };
 
 // Physics simulation step rate for KHR_physics_rigid_bodies models.
 const PHYSICS_FPS = 60;
@@ -1202,7 +1204,7 @@ async function setupGltfPhysics(scene, engine, json, loadedAsset, glbBin, baseUr
 
 async function createScene(engine, modelSource) {
     const scene = createSceneContext(engine);
-    scene.clearColor = { r: 1, g: 1, b: 1, a: 1 };
+    scene.clearColor = { ...CLEAR_COLOR_CUBEMAP_ON };
 
     const modelInfo = modelSource.modelInfo;
     // Indexed models load from a URL; drag-dropped ones arrive as a self-contained GLB Blob.
@@ -1342,6 +1344,9 @@ function setupSceneGui(scene) {
 
     params.CUBEMAP = true;
     gui.add(params, 'CUBEMAP').name('CubeMap').onChange(function(value) {
+        scene.clearColor = value
+            ? { ...CLEAR_COLOR_CUBEMAP_ON }
+            : { ...CLEAR_COLOR_CUBEMAP_OFF };
         if (!skyboxRenderable) return;
         const idx = scene._renderables.indexOf(skyboxRenderable);
         if (value && idx === -1) {
@@ -1446,7 +1451,7 @@ function setupSceneGui(scene) {
 
 async function createEmptyScene(engine) {
     const scene = createSceneContext(engine);
-    scene.clearColor = { r: 1, g: 1, b: 1, a: 1 };
+    scene.clearColor = { ...CLEAR_COLOR_CUBEMAP_ON };
     const cam = createDefaultCamera(scene);
     attachControl(cam, canvas, scene);
     return scene;


### PR DESCRIPTION
## Summary
- Update Babylon Lite import map from `@babylonjs/lite@1.10.0` to `@babylonjs/lite@1.13.0`
- Align Babylon Lite viewer behavior with Babylon.js when CubeMap is OFF by using a dark blue background
- Keep CubeMap ON background behavior unchanged (white)

## Changes
- `examples/babylon-lite/index.html`
  - Updated Babylon Lite ESM URL to `https://esm.sh/@babylonjs/lite@1.13.0?bundle`
  - Updated version comment to `v1.13.0`
- `examples/babylon-lite/index.js`
  - Added clear-color constants for CubeMap ON/OFF states
  - Applied clear color when toggling `CubeMap` in GUI
  - Kept initial/empty scene clear color aligned with CubeMap ON state

## Validation
- Confirmed only the following files are included in this PR:
  - `examples/babylon-lite/index.html`
  - `examples/babylon-lite/index.js`
- Visually checked CubeMap OFF background tone to match the Babylon.js viewer reference