### PR TITLE
Bump Babylon Lite to v1.15.0

### DIFF
--- a/examples/babylon-lite/index.html
+++ b/examples/babylon-lite/index.html
@@ -5,11 +5,11 @@
 <link rel="stylesheet" type="text/css" media="screen,print" href="style.css" />
 <title>[WebGPU] Babylon Lite + glTFLoader</title>
 
-<!-- @babylonjs/lite v1.13.0 (loaded via importmap) -->
+<!-- @babylonjs/lite v1.15.0 (loaded via importmap) -->
 <script type="importmap">
 {
   "imports": {
-    "babylon-lite": "https://esm.sh/@babylonjs/lite@1.13.0?bundle",
+    "babylon-lite": "https://esm.sh/@babylonjs/lite@1.15.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }


### PR DESCRIPTION
## Summary
- Update Babylon Lite import map from `@babylonjs/lite@1.13.0` to `@babylonjs/lite@1.15.0`
- Keep the Babylon Lite version comment in sync with the import map version

## Changes
- Updated `examples/babylon-lite/index.html`
  - `https://esm.sh/@babylonjs/lite@1.13.0?bundle` -> `https://esm.sh/@babylonjs/lite@1.15.0?bundle`
  - `@babylonjs/lite v1.13.0` -> `@babylonjs/lite v1.15.0`

## Validation
- PR includes exactly one commit
- PR changes only one file:
  - `examples/babylon-lite/index.html`