### PR TITLE
Update Babylon Lite to 1.21.0

### DIFF
--- a/examples/babylon-lite/index.html
+++ b/examples/babylon-lite/index.html
@@ -9,7 +9,7 @@
 <script type="importmap">
 {
   "imports": {
-    "babylon-lite": "https://esm.sh/@babylonjs/lite@1.19.0?bundle",
+    "babylon-lite": "https://esm.sh/@babylonjs/lite@1.21.0?bundle",
     "@babylonjs/havok": "https://esm.sh/@babylonjs/havok@1.3.12/lib/esm/HavokPhysics_es.js"
   }
 }


### PR DESCRIPTION
## Summary
- Update Babylon Lite from 1.19.0 to 1.21.0 in the Babylon Lite example import map.

## Changes
- Updated the Babylon Lite CDN URL in examples/babylon-lite/index.html.
- Adjusted the inline version comment to match the new version.
